### PR TITLE
Change main branch name to `main`

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -2,9 +2,9 @@ name: CI Build
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
 
 env:
   CARGO_TERM_COLOR: always

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,10 +21,10 @@ If a new release of some, but not all, crates is required, the version of all ot
 
 This procedure should really be automated, but for now it is at least documented.
 
-1. Make sure your local `master` branch is up-to-date:
+1. Make sure your local `main` branch is up-to-date:
 
 ``` bash
-git switch master
+git switch main
 git pull --rebase
 ```
 
@@ -61,7 +61,7 @@ git tag va.b.c
 
 ``` bash
 # missing: merge pull request
-git switch master
+git switch main
 git pull --rebase
 git remote prune origin
 git branch -d publish-a.b.c

--- a/README.md
+++ b/README.md
@@ -60,4 +60,4 @@ See [LICENSE.md] for full details.
 [STSPIN220]: https://www.st.com/en/motor-drivers/stspin220.html
 [API Reference]: https://docs.rs/step-dir
 [Zero Clause BSD License]: https://opensource.org/licenses/0BSD
-[LICENSE.md]: https://github.com/flott-motion/step-dir/blob/master/LICENSE.md
+[LICENSE.md]: https://github.com/flott-motion/step-dir/blob/main/LICENSE.md

--- a/drivers/drv8825/README.md
+++ b/drivers/drv8825/README.md
@@ -18,4 +18,4 @@ See [LICENSE.md] for full details.
 [available from pololu]: https://www.pololu.com/category/154/
 [step/dir]: https://crates.io/crates/step-dir
 [zero clause bsd license]: https://opensource.org/licenses/0BSD
-[license.md]: https://github.com/flott-motion/step-dir/blob/master/LICENSE.md
+[license.md]: https://github.com/flott-motion/step-dir/blob/main/LICENSE.md

--- a/drivers/stspin220/README.md
+++ b/drivers/stspin220/README.md
@@ -18,4 +18,4 @@ See [LICENSE.md] for full details.
 [available from pololu]: https://www.pololu.com/category/260/
 [step/dir]: https://crates.io/crates/step-dir
 [zero clause bsd license]: https://opensource.org/licenses/0BSD
-[license.md]: https://github.com/flott-motion/step-dir/blob/master/LICENSE.md
+[license.md]: https://github.com/flott-motion/step-dir/blob/main/LICENSE.md

--- a/templates/driver/README.md.tmpl
+++ b/templates/driver/README.md.tmpl
@@ -18,4 +18,4 @@ See [LICENSE.md] for full details.
 [available from pololu]: { pololu_url }
 [step/dir]: https://crates.io/crates/step-dir
 [zero clause bsd license]: https://opensource.org/licenses/0BSD
-[license.md]: https://github.com/flott-motion/step-dir/blob/master/LICENSE.md
+[license.md]: https://github.com/flott-motion/step-dir/blob/main/LICENSE.md

--- a/test-stand/README.md
+++ b/test-stand/README.md
@@ -20,7 +20,7 @@ The following hardware is used for the test stand:
 - Pololu Magnetic Encoder
   https://www.pololu.com/product/3499
 
-The electronics go on the breadboard, the motor and encoder go on a [3D-printed structure](https://github.com/flott-motion/step-dir/blob/master/test-stand/test-stand.scad).
+The electronics go on the breadboard, the motor and encoder go on a [3D-printed structure](https://github.com/flott-motion/step-dir/blob/main/test-stand/test-stand.scad).
 
 ### Wiring
 


### PR DESCRIPTION
There's a political argument for changing the name of the main branch
from `master` to `main`. I don't know what to think about that, so I'm
going to ignore it for my following arguments.

I think "main" is clearly the better name for the main/master branch:

- It is shorter and has half the number of syllables.
- It is a much clearer name. At least to me as a non-native speaker, the
  concept of a master record, which is the basis of the name "master",
  as far as I understand, is much more obscure than "main", which is a
  basic and pervasive word.

Given that, I see the following two reasons to stay with master:

1. The change is perceived as part of a political movement that induces
   a counter-reaction in many people.
2. "master" is the already established name, and changing it might lead
   to confusion.

I can't relate to argument 1, and it's part of the political argument I
was going to ignore anyway. This leaves argument 2 which, in my opinion,
has been weakened severely by recent developments:

- GitHub and other hosts have already changed their default name for the
  main branch to "main".
- Many projects have changed the name of their `master` branch to `main`
  or something else.
- Git itself has added configuration that makes changing the name of the
  main branch for new repositories easy, and might or might not change
  the default name for the main branch in the future.

Given these development, I think argument 2 is basically void. Any
confusion this could produce is already here, so we're basically left
with the choice between an established and a new name. I'm choosing the
new one, for the reasons stated above.