### PR TITLE
Rename `Driver` to `Stepper`

### DIFF
--- a/src/driver/mod.rs
+++ b/src/driver/mod.rs
@@ -20,11 +20,11 @@ use crate::{
     Direction,
 };
 
-/// Abstract interface to stepper motor drivers
+/// Abstract interface to stepper motors
 ///
-/// Wraps a concrete driver and uses the traits that the concrete driver
-/// implements to provide an abstract API. You can construct an instance of this
-/// type using [`Stepper::from_inner`].
+/// Wraps a concrete stepper driver or controller, and uses the traits that this
+/// concrete driver or controller implements to provide an abstract API. You can
+/// construct an instance of this type using [`Stepper::from_inner`].
 ///
 /// # Notes on timer use
 ///
@@ -60,48 +60,49 @@ pub struct Stepper<T> {
 }
 
 impl<T> Stepper<T> {
-    /// Create a new `Driver` instance from a concrete driver
+    /// Create a new `Stepper` instance from a concrete driver or controller
     pub fn from_inner(inner: T) -> Self {
         Self { inner }
     }
 
-    /// Access a reference to the wrapped driver
+    /// Access a reference to the wrapped driver or controller
     ///
-    /// Can be used to access driver-specific functionality that can't be
-    /// provided by `Driver`'s abstract interface.
+    /// Can be used to access driver/controller-specific functionality that
+    /// can't be provided by `Stepper`'s abstract interface.
     pub fn inner(&self) -> &T {
         &self.inner
     }
 
-    /// Access a mutable reference to the wrapped driver
+    /// Access a mutable reference to the wrapped driver or controller
     ///
-    /// Can be used to access driver-specific functionality that can't be
-    /// provided by `Driver`'s abstract interface.
+    /// Can be used to access driver/controller-specific functionality that
+    /// can't be provided by `Stepper`'s abstract interface.
     pub fn inner_mut(&mut self) -> &mut T {
         &mut self.inner
     }
 
-    /// Release the wrapped driver
+    /// Release the wrapped driver or controller
     ///
-    /// Drops this instance of `Driver` and returns the wrapped driver.
+    /// Drops this instance of `Stepper` and returns the wrapped driver/
+    /// controller.
     pub fn release(self) -> T {
         self.inner
     }
 
     /// Enable microstepping mode control
     ///
-    /// Consumes this instance of `Driver` and returns a new instance that
+    /// Consumes this instance of `Stepper` and returns a new instance that
     /// provides control over the microstepping mode. Once this method has been
     /// called, the [`Stepper::set_step_mode`] method becomes available.
     ///
     /// Takes the hardware resources that are required for controlling the
     /// microstepping mode as an argument. What exactly those are depends on the
-    /// specific driver. Typically they are the output pins that are connected
-    /// to the mode pins of the driver.
+    /// specific driver/controller. Typically they are the output pins that are
+    /// connected to the mode pins of the driver/controller.
     ///
-    /// This method is only available, if the driver supports enabling step mode
-    /// control. It might no longer be available, once step mode control has
-    /// been enabled.
+    /// This method is only available, if the driver/controller supports
+    /// enabling step mode control. It might no longer be available, once step
+    /// mode control has been enabled.
     pub fn enable_step_mode_control<Resources, Timer>(
         self,
         res: Resources,
@@ -130,10 +131,10 @@ impl<T> Stepper<T> {
 
     /// Sets the microstepping mode
     ///
-    /// This method is only available, if the wrapped driver supports
+    /// This method is only available, if the wrapped driver/controller supports
     /// microstepping, and supports setting the step mode through software. Some
-    /// drivers might not support microstepping at all, or only allow setting
-    /// the step mode by changing physical switches.
+    /// drivers/controllers might not support microstepping at all, or only
+    /// allow setting the step mode by changing physical switches.
     ///
     /// You might need to call [`Stepper::enable_step_mode_control`] to make
     /// this method available.
@@ -152,18 +153,18 @@ impl<T> Stepper<T> {
 
     /// Enable direction control
     ///
-    /// Consumes this instance of `Driver` and returns a new instance that
+    /// Consumes this instance of `Stepper` and returns a new instance that
     /// provides control over the motor direction. Once this method has been
     /// called, the [`Stepper::set_direction`] method becomes available.
     ///
     /// Takes the hardware resources that are required for controlling the
     /// direction as an argument. What exactly those are depends on the specific
-    /// driver. Typically it's going to be the output pin that is connected to
-    /// the driver's DIR pin.
+    /// driver/controller. Typically it's going to be the output pin that is
+    /// connected to the driver/controller's DIR pin.
     ///
-    /// This method is only available, if the driver supports enabling direction
-    /// control. It might no longer be available, once direction control has
-    /// been enabled.
+    /// This method is only available, if the driver/controller supports
+    /// enabling direction control. It might no longer be available, once
+    /// direction control has been enabled.
     pub fn enable_direction_control<Resources, Timer>(
         self,
         res: Resources,
@@ -209,18 +210,18 @@ impl<T> Stepper<T> {
 
     /// Enable step control
     ///
-    /// Consumes this instance of `Driver` and returns a new instance that
+    /// Consumes this instance of `Stepper` and returns a new instance that
     /// provides control over stepping the motor. Once this method has been
     /// called, the [`Stepper::step`] method becomes available.
     ///
     /// Takes the hardware resources that are required for controlling the
     /// direction as an argument. What exactly those are depends on the specific
-    /// driver. Typically it's going to be the output pin that is connected to
-    /// the driver's STEP pin.
+    /// driver/controller. Typically it's going to be the output pin that is
+    /// connected to the driver/controller's STEP pin.
     ///
-    /// This method is only available, if the driver supports enabling step
-    /// control. It might no longer be available, once step control has been
-    /// enabled.
+    /// This method is only available, if the driver/controller supports
+    /// enabling step control. It might no longer be available, once step
+    /// control has been enabled.
     pub fn enable_step_control<Resources>(
         self,
         res: Resources,
@@ -253,7 +254,7 @@ impl<T> Stepper<T> {
         StepFuture::new(self, timer)
     }
 
-    /// Returns the step pulse length of the wrapped driver
+    /// Returns the step pulse length of the wrapped driver/controller
     ///
     /// The pulse length is also available through the [`Step`] trait. This
     /// method provides a more convenient way to access it.

--- a/src/driver/mod.rs
+++ b/src/driver/mod.rs
@@ -24,7 +24,7 @@ use crate::{
 ///
 /// Wraps a concrete driver and uses the traits that the concrete driver
 /// implements to provide an abstract API. You can construct an instance of this
-/// type using [`Driver::from_inner`].
+/// type using [`Stepper::from_inner`].
 ///
 /// # Notes on timer use
 ///
@@ -55,11 +55,11 @@ use crate::{
 ///
 /// [RFC 2632]: https://github.com/rust-lang/rfcs/pull/2632
 /// [RFC 2920]: https://github.com/rust-lang/rfcs/pull/2920
-pub struct Driver<T> {
+pub struct Stepper<T> {
     inner: T,
 }
 
-impl<T> Driver<T> {
+impl<T> Stepper<T> {
     /// Create a new `Driver` instance from a concrete driver
     pub fn from_inner(inner: T) -> Self {
         Self { inner }
@@ -92,7 +92,7 @@ impl<T> Driver<T> {
     ///
     /// Consumes this instance of `Driver` and returns a new instance that
     /// provides control over the microstepping mode. Once this method has been
-    /// called, the [`Driver::set_step_mode`] method becomes available.
+    /// called, the [`Stepper::set_step_mode`] method becomes available.
     ///
     /// Takes the hardware resources that are required for controlling the
     /// microstepping mode as an argument. What exactly those are depends on the
@@ -108,7 +108,7 @@ impl<T> Driver<T> {
         initial: <T::WithStepModeControl as SetStepMode>::StepMode,
         timer: &mut Timer,
     ) -> Result<
-        Driver<T::WithStepModeControl>,
+        Stepper<T::WithStepModeControl>,
         Error<
             <T::WithStepModeControl as SetStepMode>::Error,
             <Timer::Time as TryFrom<Nanoseconds>>::Error,
@@ -120,7 +120,7 @@ impl<T> Driver<T> {
         Timer: timer::CountDown,
         Timer::Time: TryFrom<Nanoseconds>,
     {
-        let mut self_ = Driver {
+        let mut self_ = Stepper {
             inner: self.inner.enable_step_mode_control(res),
         };
         self_.set_step_mode(initial, timer).wait()?;
@@ -135,8 +135,8 @@ impl<T> Driver<T> {
     /// drivers might not support microstepping at all, or only allow setting
     /// the step mode by changing physical switches.
     ///
-    /// You might need to call [`Driver::enable_step_mode_control`] to make this
-    /// method available.
+    /// You might need to call [`Stepper::enable_step_mode_control`] to make
+    /// this method available.
     pub fn set_step_mode<'r, Timer>(
         &'r mut self,
         step_mode: T::StepMode,
@@ -154,7 +154,7 @@ impl<T> Driver<T> {
     ///
     /// Consumes this instance of `Driver` and returns a new instance that
     /// provides control over the motor direction. Once this method has been
-    /// called, the [`Driver::set_direction`] method becomes available.
+    /// called, the [`Stepper::set_direction`] method becomes available.
     ///
     /// Takes the hardware resources that are required for controlling the
     /// direction as an argument. What exactly those are depends on the specific
@@ -170,7 +170,7 @@ impl<T> Driver<T> {
         initial: Direction,
         timer: &mut Timer,
     ) -> Result<
-        Driver<T::WithDirectionControl>,
+        Stepper<T::WithDirectionControl>,
         Error<
             <T::WithDirectionControl as SetDirection>::Error,
             <Timer::Time as TryFrom<Nanoseconds>>::Error,
@@ -182,7 +182,7 @@ impl<T> Driver<T> {
         Timer: timer::CountDown,
         Timer::Time: TryFrom<Nanoseconds>,
     {
-        let mut self_ = Driver {
+        let mut self_ = Stepper {
             inner: self.inner.enable_direction_control(res),
         };
         self_.set_direction(initial, timer).wait()?;
@@ -192,8 +192,8 @@ impl<T> Driver<T> {
 
     /// Set direction for future movements
     ///
-    /// You might need to call [`Driver::enable_direction_control`] to make this
-    /// method available.
+    /// You might need to call [`Stepper::enable_direction_control`] to make
+    /// this method available.
     pub fn set_direction<'r, Timer>(
         &'r mut self,
         direction: Direction,
@@ -211,7 +211,7 @@ impl<T> Driver<T> {
     ///
     /// Consumes this instance of `Driver` and returns a new instance that
     /// provides control over stepping the motor. Once this method has been
-    /// called, the [`Driver::step`] method becomes available.
+    /// called, the [`Stepper::step`] method becomes available.
     ///
     /// Takes the hardware resources that are required for controlling the
     /// direction as an argument. What exactly those are depends on the specific
@@ -224,11 +224,11 @@ impl<T> Driver<T> {
     pub fn enable_step_control<Resources>(
         self,
         res: Resources,
-    ) -> Driver<T::WithStepControl>
+    ) -> Stepper<T::WithStepControl>
     where
         T: EnableStepControl<Resources>,
     {
-        Driver {
+        Stepper {
             inner: self.inner.enable_step_control(res),
         }
     }
@@ -239,7 +239,7 @@ impl<T> Driver<T> {
     /// according to current microstepping configuration. To achieve a specific
     /// speed, the user must call this method at an appropriate frequency.
     ///
-    /// You might need to call [`Driver::enable_step_control`] to make this
+    /// You might need to call [`Stepper::enable_step_control`] to make this
     /// method available.
     pub fn step<'r, Timer>(
         &'r mut self,

--- a/src/driver/set_direction.rs
+++ b/src/driver/set_direction.rs
@@ -17,7 +17,7 @@ use super::{Error, Stepper};
 /// development becomes more practical.
 pub struct SetDirectionFuture<'r, T, Timer> {
     direction: Direction,
-    driver: &'r mut Stepper<T>,
+    stepper: &'r mut Stepper<T>,
     timer: &'r mut Timer,
     state: State,
 }
@@ -30,12 +30,12 @@ where
 {
     pub(super) fn new(
         direction: Direction,
-        driver: &'r mut Stepper<T>,
+        stepper: &'r mut Stepper<T>,
         timer: &'r mut Timer,
     ) -> Self {
         Self {
             direction,
-            driver,
+            stepper,
             timer,
             state: State::Initial,
         }
@@ -68,13 +68,13 @@ where
             State::Initial => {
                 match self.direction {
                     Direction::Forward => self
-                        .driver
+                        .stepper
                         .inner
                         .dir()
                         .try_set_high()
                         .map_err(|err| Error::Pin(err))?,
                     Direction::Backward => self
-                        .driver
+                        .stepper
                         .inner
                         .dir()
                         .try_set_low()

--- a/src/driver/set_direction.rs
+++ b/src/driver/set_direction.rs
@@ -8,16 +8,16 @@ use embedded_time::duration::Nanoseconds;
 
 use crate::{traits::SetDirection, Direction};
 
-use super::{Driver, Error};
+use super::{Error, Stepper};
 
-/// A "future" that can be polled to complete a [`Driver::set_direction`] call
+/// A "future" that can be polled to complete a [`Stepper::set_direction`] call
 ///
 /// Please note that this type provides a custom API and does not implement
 /// [`core::future::Future`]. This might change, as using futures for embedded
 /// development becomes more practical.
 pub struct SetDirectionFuture<'r, T, Timer> {
     direction: Direction,
-    driver: &'r mut Driver<T>,
+    driver: &'r mut Stepper<T>,
     timer: &'r mut Timer,
     state: State,
 }
@@ -30,7 +30,7 @@ where
 {
     pub(super) fn new(
         direction: Direction,
-        driver: &'r mut Driver<T>,
+        driver: &'r mut Stepper<T>,
         timer: &'r mut Timer,
     ) -> Self {
         Self {

--- a/src/driver/set_step_mode.rs
+++ b/src/driver/set_step_mode.rs
@@ -8,16 +8,16 @@ use embedded_time::duration::Nanoseconds;
 
 use crate::traits::SetStepMode;
 
-use super::{Driver, Error};
+use super::{Error, Stepper};
 
-/// A "future" that can be polled to complete a [`Driver::set_step_mode`] call
+/// A "future" that can be polled to complete a [`Stepper::set_step_mode`] call
 ///
 /// Please note that this type provides a custom API and does not implement
 /// [`core::future::Future`]. This might change, as using futures for embedded
 /// development becomes more practical.
 pub struct SetStepModeFuture<'r, T: SetStepMode, Timer> {
     step_mode: T::StepMode,
-    driver: &'r mut Driver<T>,
+    driver: &'r mut Stepper<T>,
     timer: &'r mut Timer,
     state: State,
 }
@@ -30,7 +30,7 @@ where
 {
     pub(super) fn new(
         step_mode: T::StepMode,
-        driver: &'r mut Driver<T>,
+        driver: &'r mut Stepper<T>,
         timer: &'r mut Timer,
     ) -> Self {
         Self {

--- a/src/driver/set_step_mode.rs
+++ b/src/driver/set_step_mode.rs
@@ -17,7 +17,7 @@ use super::{Error, Stepper};
 /// development becomes more practical.
 pub struct SetStepModeFuture<'r, T: SetStepMode, Timer> {
     step_mode: T::StepMode,
-    driver: &'r mut Stepper<T>,
+    stepper: &'r mut Stepper<T>,
     timer: &'r mut Timer,
     state: State,
 }
@@ -30,12 +30,12 @@ where
 {
     pub(super) fn new(
         step_mode: T::StepMode,
-        driver: &'r mut Stepper<T>,
+        stepper: &'r mut Stepper<T>,
         timer: &'r mut Timer,
     ) -> Self {
         Self {
             step_mode,
-            driver,
+            stepper,
             timer,
             state: State::Initial,
         }
@@ -66,7 +66,7 @@ where
     > {
         match self.state {
             State::Initial => {
-                self.driver
+                self.stepper
                     .inner
                     .apply_mode_config(self.step_mode)
                     .map_err(|err| Error::Pin(err))?;
@@ -83,7 +83,7 @@ where
             }
             State::ApplyingConfig => match self.timer.try_wait() {
                 Ok(()) => {
-                    self.driver
+                    self.stepper
                         .inner
                         .enable_driver()
                         .map_err(|err| Error::Pin(err))?;

--- a/src/driver/step.rs
+++ b/src/driver/step.rs
@@ -8,15 +8,15 @@ use embedded_time::duration::Nanoseconds;
 
 use crate::traits::Step;
 
-use super::{Driver, Error};
+use super::{Error, Stepper};
 
-/// A "future" that can be polled to complete a [`Driver::step`] call
+/// A "future" that can be polled to complete a [`Stepper::step`] call
 ///
 /// Please note that this type provides a custom API and does not implement
 /// [`core::future::Future`]. This might change, as using futures for embedded
 /// development becomes more practical.
 pub struct StepFuture<'r, T, Timer> {
-    driver: &'r mut Driver<T>,
+    driver: &'r mut Stepper<T>,
     timer: &'r mut Timer,
     state: State,
 }
@@ -27,7 +27,10 @@ where
     Timer: timer::CountDown,
     Timer::Time: TryFrom<Nanoseconds>,
 {
-    pub(super) fn new(driver: &'r mut Driver<T>, timer: &'r mut Timer) -> Self {
+    pub(super) fn new(
+        driver: &'r mut Stepper<T>,
+        timer: &'r mut Timer,
+    ) -> Self {
         Self {
             driver,
             timer,

--- a/src/driver/step.rs
+++ b/src/driver/step.rs
@@ -16,7 +16,7 @@ use super::{Error, Stepper};
 /// [`core::future::Future`]. This might change, as using futures for embedded
 /// development becomes more practical.
 pub struct StepFuture<'r, T, Timer> {
-    driver: &'r mut Stepper<T>,
+    stepper: &'r mut Stepper<T>,
     timer: &'r mut Timer,
     state: State,
 }
@@ -28,11 +28,11 @@ where
     Timer::Time: TryFrom<Nanoseconds>,
 {
     pub(super) fn new(
-        driver: &'r mut Stepper<T>,
+        stepper: &'r mut Stepper<T>,
         timer: &'r mut Timer,
     ) -> Self {
         Self {
-            driver,
+            stepper,
             timer,
             state: State::Initial,
         }
@@ -64,7 +64,7 @@ where
         match self.state {
             State::Initial => {
                 // Start step pulse
-                self.driver
+                self.stepper
                     .inner
                     .step()
                     .try_set_high()
@@ -84,7 +84,7 @@ where
                 match self.timer.try_wait() {
                     Ok(()) => {
                         // End step pulse
-                        self.driver
+                        self.stepper
                             .inner
                             .step()
                             .try_set_low()

--- a/src/drivers/drv8825.rs
+++ b/src/drivers/drv8825.rs
@@ -5,7 +5,7 @@
 //! traits are available.
 //!
 //! For the most part, users are not expected to use this API directly. Please
-//! check out [`Driver`](crate::Driver) instead.
+//! check out [`Stepper`](crate::Stepper) instead.
 //!
 //! [embedded-hal]: https://crates.io/crates/embedded-hal
 
@@ -23,8 +23,8 @@ use crate::{
 /// The DRV8825 driver API
 ///
 /// Users are not expected to use this API directly, except to create an
-/// instance using [`DRV8825::new`]. Please check out [`Driver`](crate::Driver)
-/// instead.
+/// instance using [`DRV8825::new`]. Please check out
+/// [`Stepper`](crate::Stepper) instead.
 pub struct DRV8825<Enable, Fault, Sleep, Reset, Mode0, Mode1, Mode2, Step, Dir>
 {
     enable: Enable,

--- a/src/drivers/stspin220.rs
+++ b/src/drivers/stspin220.rs
@@ -5,7 +5,7 @@
 //! traits are available.
 //!
 //! For the most part, users are not expected to use this API directly. Please
-//! check out [`Driver`](crate::Driver) instead.
+//! check out [`Stepper`](crate::Stepper) instead.
 //!
 //! [embedded-hal]: https://crates.io/crates/embedded-hal
 
@@ -24,7 +24,7 @@ use crate::{
 ///
 /// Users are not expected to use this API directly, except to create an
 /// instance using [`STSPIN220::new`]. Please check out
-/// [`Driver`](crate::Driver) instead.
+/// [`Stepper`](crate::Stepper) instead.
 pub struct STSPIN220<
     EnableFault,
     StandbyReset,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -101,7 +101,7 @@
 //! //
 //! // Here, we enable control over the STEP and DIR pins, as we want to step
 //! // the motor in a defined direction.
-//! let mut driver = Stepper::from_inner(MyDriver::new())
+//! let mut stepper = Stepper::from_inner(MyDriver::new())
 //!     .enable_direction_control(dir, Direction::Forward, &mut timer)?
 //!     .enable_step_control(step);
 //!
@@ -110,13 +110,13 @@
 //!     // The `step` method returns a future. We just use it to block until the
 //!     // operation completes, but you can also use the API in a non-blocking
 //!     // way.
-//!     driver.step(&mut timer).wait()?;
+//!     stepper.step(&mut timer).wait()?;
 //!
 //!     // After telling the driver to make a step, we need to make sure to call
 //!     // the step method again after an appropriate amount of time. Let's just
 //!     // wait for the right time, using this example `delay_ns` function. How
 //!     // you do this in your own code is up to you.
-//!     delay_ns(STEP_DELAY - driver.pulse_length());
+//!     delay_ns(STEP_DELAY - stepper.pulse_length());
 //! }
 //! #
 //! # Ok(())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,7 @@
 //! - [DRV8825](crate::drivers::drv8825::DRV8825)
 //! - [STSPIN220](crate::drivers::stspin220::STSPIN220)
 //!
-//! Please check out the documentation of [`Driver`], which is the main entry
+//! Please check out the documentation of [`Stepper`], which is the main entry
 //! point to this API.
 //!
 //! # Example
@@ -33,7 +33,7 @@
 //! #
 //! use step_dir::{
 //!     embedded_time::duration::Nanoseconds,
-//!     Direction, Driver,
+//!     Direction, Stepper,
 //! };
 //!
 //! // This constant defines how much time there is between two steps. Changing
@@ -101,7 +101,7 @@
 //! //
 //! // Here, we enable control over the STEP and DIR pins, as we want to step
 //! // the motor in a defined direction.
-//! let mut driver = Driver::from_inner(MyDriver::new())
+//! let mut driver = Stepper::from_inner(MyDriver::new())
 //!     .enable_direction_control(dir, Direction::Forward, &mut timer)?
 //!     .enable_step_control(step);
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,11 +89,12 @@
 //! // again, we'll use a mock here for the sake of demonstration.
 //! let mut timer = Timer;
 //!
-//! // Now we need to initialize the driver API. We do this by creating a
-//! // driver-specific API (`MyDriver`), then wrapping that into the generic API
-//! // (`Driver`). `MyDriver` is a placeholder. In a real use-case, you'd
-//! // typically use one of the drivers from the `step_dir::drivers` module, but
-//! // any driver that implements the traits from `step_dir::traits` will work.
+//! // Now we need to initialize the stepper API. We do this by creating a
+//! // driver/controller-specific API (`MyStepper`), then wrapping that into the
+//! // generic API (`Stepper`). `MyStepper` is a placeholder. In a real
+//! // use-case, you'd typically use one of the drivers from the
+//! // `step_dir::drivers` module, but any driver that implements the traits
+//! // from `step_dir::traits` will work.
 //! //
 //! // By default, drivers can't do anything directly after being initialized.
 //! // This means they also don't require any hardware resources, which makes

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,7 +42,7 @@
 //!
 //! # // Use a real driver to make things easy, without making the example seem
 //! # // to specific to one driver.
-//! # type MyDriver = step_dir::drivers::drv8825::DRV8825<
+//! # type MyStepper = step_dir::drivers::drv8825::DRV8825<
 //! #     (), (), (), (), (), (), (), (), ()
 //! # >;
 //! #
@@ -101,7 +101,7 @@
 //! //
 //! // Here, we enable control over the STEP and DIR pins, as we want to step
 //! // the motor in a defined direction.
-//! let mut stepper = Stepper::from_inner(MyDriver::new())
+//! let mut stepper = Stepper::from_inner(MyStepper::new())
 //!     .enable_direction_control(dir, Direction::Forward, &mut timer)?
 //!     .enable_step_control(step);
 //!

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -1,7 +1,7 @@
 //! Traits that can be implemented by Step/Dir drivers
 //!
 //! Users are generally not expected to use these traits directly, except to
-//! specify trait bounds, where necessary. Please check out [`Driver`], which
+//! specify trait bounds, where necessary. Please check out [`Stepper`], which
 //! uses these traits to provide the public API.
 //!
 //! There are two kinds of traits in this module:
@@ -18,7 +18,7 @@
 //! This approach also provides a lot of flexibility for non-standard use cases,
 //! for example if not all driver capabilities are controlled by software.
 //!
-//! [`Driver`]: crate::Driver
+//! [`Stepper`]: crate::Stepper
 
 use embedded_hal::digital::OutputPin;
 use embedded_time::duration::Nanoseconds;

--- a/test-stand/src/lib.rs
+++ b/test-stand/src/lib.rs
@@ -31,7 +31,7 @@ pub fn exit() -> ! {
 }
 
 pub fn test_step<D, A, B, DebugSignal, Error>(
-    driver: &mut Stepper<D>,
+    stepper: &mut Stepper<D>,
     timer: &mut mrt::Channel<MRT0>,
     rotary: &mut Rotary<A, B>,
     debug_signal: &mut DebugSignal,
@@ -45,8 +45,8 @@ pub fn test_step<D, A, B, DebugSignal, Error>(
     DebugSignal: OutputPin,
     DebugSignal::Error: Debug,
 {
-    verify_steps(driver, timer, rotary, Direction::Forward, debug_signal);
-    verify_steps(driver, timer, rotary, Direction::Backward, debug_signal);
+    verify_steps(stepper, timer, rotary, Direction::Forward, debug_signal);
+    verify_steps(stepper, timer, rotary, Direction::Backward, debug_signal);
 }
 
 pub fn verify_steps<D, A, B, DebugSignal, Error>(

--- a/test-stand/src/lib.rs
+++ b/test-stand/src/lib.rs
@@ -118,7 +118,7 @@ pub fn verify_steps<D, A, B, DebugSignal, Error>(
 }
 
 pub fn step<D, A, B, Error>(
-    driver: &mut Stepper<D>,
+    stepper: &mut Stepper<D>,
     timer: &mut mrt::Channel<MRT0>,
     rotary: &mut Rotary<A, B>,
     delay: Microseconds,
@@ -138,12 +138,12 @@ where
         Direction::Backward => EncoderDirection::CounterClockwise,
     };
 
-    driver.set_direction(direction, timer).wait().unwrap();
-    driver.step(timer).wait().unwrap();
+    stepper.set_direction(direction, timer).wait().unwrap();
+    stepper.step(timer).wait().unwrap();
 
     timer.start(mrt::MAX_VALUE);
     let step_timer = timer
-        .new_timer(delay - driver.pulse_length())
+        .new_timer(delay - stepper.pulse_length())
         .start()
         .unwrap();
 

--- a/test-stand/src/lib.rs
+++ b/test-stand/src/lib.rs
@@ -20,7 +20,7 @@ use step_dir::{
     embedded_hal::digital::{InputPin, OutputPin},
     embedded_time::{duration::Microseconds, Clock},
     traits::{SetDirection, Step},
-    Direction, Driver,
+    Direction, Stepper,
 };
 
 /// Causes probe-run to exit with exit code 0
@@ -31,7 +31,7 @@ pub fn exit() -> ! {
 }
 
 pub fn test_step<D, A, B, DebugSignal, Error>(
-    driver: &mut Driver<D>,
+    driver: &mut Stepper<D>,
     timer: &mut mrt::Channel<MRT0>,
     rotary: &mut Rotary<A, B>,
     debug_signal: &mut DebugSignal,
@@ -50,7 +50,7 @@ pub fn test_step<D, A, B, DebugSignal, Error>(
 }
 
 pub fn verify_steps<D, A, B, DebugSignal, Error>(
-    driver: &mut Driver<D>,
+    driver: &mut Stepper<D>,
     timer: &mut mrt::Channel<MRT0>,
     rotary: &mut Rotary<A, B>,
     direction: Direction,
@@ -118,7 +118,7 @@ pub fn verify_steps<D, A, B, DebugSignal, Error>(
 }
 
 pub fn step<D, A, B, Error>(
-    driver: &mut Driver<D>,
+    driver: &mut Stepper<D>,
     timer: &mut mrt::Channel<MRT0>,
     rotary: &mut Rotary<A, B>,
     delay: Microseconds,

--- a/test-stand/src/lib.rs
+++ b/test-stand/src/lib.rs
@@ -50,7 +50,7 @@ pub fn test_step<D, A, B, DebugSignal, Error>(
 }
 
 pub fn verify_steps<D, A, B, DebugSignal, Error>(
-    driver: &mut Stepper<D>,
+    stepper: &mut Stepper<D>,
     timer: &mut mrt::Channel<MRT0>,
     rotary: &mut Rotary<A, B>,
     direction: Direction,
@@ -93,9 +93,9 @@ pub fn verify_steps<D, A, B, DebugSignal, Error>(
     //
     // Here we step the motor until we read a count, then move half the number
     // of steps that make up a count, to get us to a desired middle position.
-    while step(driver, timer, rotary, STEP_DELAY, direction, false) == 0 {}
+    while step(stepper, timer, rotary, STEP_DELAY, direction, false) == 0 {}
     for _ in 0..STEPS_PER_COUNT / 2 {
-        step(driver, timer, rotary, STEP_DELAY, direction, false);
+        step(stepper, timer, rotary, STEP_DELAY, direction, false);
     }
 
     // Setup movement is over. Lower test signal.
@@ -106,7 +106,7 @@ pub fn verify_steps<D, A, B, DebugSignal, Error>(
 
     let mut counts = 0;
     for _ in 0..steps {
-        counts += step(driver, timer, rotary, STEP_DELAY, direction, true);
+        counts += step(stepper, timer, rotary, STEP_DELAY, direction, true);
     }
 
     defmt::info!(

--- a/test-stand/tests/tests/stspin220.rs
+++ b/test-stand/tests/tests/stspin220.rs
@@ -25,7 +25,7 @@ use test_stand::{
 };
 
 struct Context {
-    driver: Stepper<
+    stepper: Stepper<
         STSPIN220<
             (),
             GpioPin<PIO0_16, Output>,
@@ -86,7 +86,7 @@ mod tests {
 
         let mut timer = mrt.mrt0;
 
-        let driver = Stepper::from_inner(STSPIN220::new())
+        let stepper = Stepper::from_inner(STSPIN220::new())
             .enable_step_control(step_mode3)
             .enable_direction_control(dir_mode4, Direction::Forward, &mut timer)
             .unwrap()
@@ -100,7 +100,7 @@ mod tests {
         let rotary = Rotary::new(rotary_a, rotary_b);
 
         super::Context {
-            driver,
+            stepper,
             timer,
             rotary,
             debug_signal,
@@ -110,7 +110,7 @@ mod tests {
     #[test]
     fn test_step(cx: &mut super::Context) {
         super::test_step(
-            &mut cx.driver,
+            &mut cx.stepper,
             &mut cx.timer,
             &mut cx.rotary,
             &mut cx.debug_signal,

--- a/test-stand/tests/tests/stspin220.rs
+++ b/test-stand/tests/tests/stspin220.rs
@@ -19,13 +19,13 @@ use test_stand::{
     rotary_encoder_hal::Rotary,
     step_dir::{
         drivers::stspin220::STSPIN220, step_mode::StepMode256, Direction,
-        Driver,
+        Stepper,
     },
     test_step,
 };
 
 struct Context {
-    driver: Driver<
+    driver: Stepper<
         STSPIN220<
             (),
             GpioPin<PIO0_16, Output>,
@@ -45,7 +45,8 @@ mod tests {
     #[init]
     fn init() -> super::Context {
         use super::{
-            gpio, lpc8xx_hal, Direction, Driver, Rotary, StepMode256, STSPIN220,
+            gpio, lpc8xx_hal, Direction, Rotary, StepMode256, Stepper,
+            STSPIN220,
         };
 
         let p = lpc8xx_hal::Peripherals::take().unwrap();
@@ -85,7 +86,7 @@ mod tests {
 
         let mut timer = mrt.mrt0;
 
-        let driver = Driver::from_inner(STSPIN220::new())
+        let driver = Stepper::from_inner(STSPIN220::new())
             .enable_step_control(step_mode3)
             .enable_direction_control(dir_mode4, Direction::Forward, &mut timer)
             .unwrap()


### PR DESCRIPTION
Also updates a bunch of references to it around the code base.