### PR TITLE
Clarify nomenclature used by `Stepper`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,7 +42,7 @@
 //!
 //! # // Use a real driver to make things easy, without making the example seem
 //! # // too specific to one driver.
-//! # type MyStepper = step_dir::drivers::drv8825::DRV8825<
+//! # type MyDriver = step_dir::drivers::drv8825::DRV8825<
 //! #     (), (), (), (), (), (), (), (), ()
 //! # >;
 //! #
@@ -90,8 +90,8 @@
 //! let mut timer = Timer;
 //!
 //! // Now we need to initialize the stepper API. We do this by creating a
-//! // driver/controller-specific API (`MyStepper`), then wrapping that into the
-//! // generic API (`Stepper`). `MyStepper` is a placeholder. In a real
+//! // driver/controller-specific API (`MyDriver`), then wrapping that into the
+//! // generic API (`Stepper`). `MyDriver` is a placeholder. In a real
 //! // use-case, you'd typically use one of the drivers from the
 //! // `step_dir::drivers` module, but any driver that implements the traits
 //! // from `step_dir::traits` will work.
@@ -102,7 +102,7 @@
 //! //
 //! // Here, we enable control over the STEP and DIR pins, as we want to step
 //! // the motor in a defined direction.
-//! let mut stepper = Stepper::from_driver(MyStepper::new())
+//! let mut stepper = Stepper::from_driver(MyDriver::new())
 //!     .enable_direction_control(dir, Direction::Forward, &mut timer)?
 //!     .enable_step_control(step);
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -102,7 +102,7 @@
 //! //
 //! // Here, we enable control over the STEP and DIR pins, as we want to step
 //! // the motor in a defined direction.
-//! let mut stepper = Stepper::from_inner(MyStepper::new())
+//! let mut stepper = Stepper::from_driver(MyStepper::new())
 //!     .enable_direction_control(dir, Direction::Forward, &mut timer)?
 //!     .enable_step_control(step);
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,7 +41,7 @@
 //! const STEP_DELAY: Nanoseconds = Nanoseconds(500_000);
 //!
 //! # // Use a real driver to make things easy, without making the example seem
-//! # // to specific to one driver.
+//! # // too specific to one driver.
 //! # type MyStepper = step_dir::drivers::drv8825::DRV8825<
 //! #     (), (), (), (), (), (), (), (), ()
 //! # >;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,16 +89,15 @@
 //! // again, we'll use a mock here for the sake of demonstration.
 //! let mut timer = Timer;
 //!
-//! // Now we need to initialize the stepper API. We do this by creating a
-//! // driver/controller-specific API (`MyDriver`), then wrapping that into the
-//! // generic API (`Stepper`). `MyDriver` is a placeholder. In a real
-//! // use-case, you'd typically use one of the drivers from the
-//! // `step_dir::drivers` module, but any driver that implements the traits
-//! // from `step_dir::traits` will work.
+//! // Now we need to initialize the stepper API. We do this by initializing a
+//! // driver (`MyDriver`), then wrapping that into the generic API (`Stepper`).
+//! // `MyDriver` is a placeholder. In a real use-case, you'd typically use one
+//! // of the drivers from the `step_dir::drivers` module, but any driver that
+//! // implements the traits from `step_dir::traits` will do.
 //! //
-//! // By default, drivers can't do anything directly after being initialized.
-//! // This means they also don't require any hardware resources, which makes
-//! // them easier to use when you don't need all features.
+//! // By default, drivers can't do anything after being initialized. This means
+//! // they also don't require any hardware resources, which makes them easier
+//! // to use when you don't need all features.
 //! //
 //! // Here, we enable control over the STEP and DIR pins, as we want to step
 //! // the motor in a defined direction.

--- a/src/stepper/mod.rs
+++ b/src/stepper/mod.rs
@@ -275,6 +275,9 @@ impl<T> Stepper<T> {
     ///
     /// The pulse length is also available through the [`Step`] trait. This
     /// method provides a more convenient way to access it.
+    ///
+    /// You might need to call [`Stepper::enable_step_control`] to make this
+    /// method available.
     pub fn pulse_length(&self) -> Nanoseconds
     where
         T: Step,

--- a/src/stepper/mod.rs
+++ b/src/stepper/mod.rs
@@ -73,13 +73,13 @@ use crate::{
 ///
 /// [RFC 2632]: https://github.com/rust-lang/rfcs/pull/2632
 /// [RFC 2920]: https://github.com/rust-lang/rfcs/pull/2920
-pub struct Stepper<T> {
-    inner: T,
+pub struct Stepper<Driver> {
+    inner: Driver,
 }
 
-impl<T> Stepper<T> {
+impl<Driver> Stepper<Driver> {
     /// Create a new `Stepper` instance from a driver
-    pub fn from_inner(inner: T) -> Self {
+    pub fn from_inner(inner: Driver) -> Self {
         Self { inner }
     }
 
@@ -87,7 +87,7 @@ impl<T> Stepper<T> {
     ///
     /// Can be used to access driver-specific functionality that can't be
     /// provided by `Stepper`'s abstract interface.
-    pub fn inner(&self) -> &T {
+    pub fn inner(&self) -> &Driver {
         &self.inner
     }
 
@@ -95,14 +95,14 @@ impl<T> Stepper<T> {
     ///
     /// Can be used to access driver-specific functionality that can't be
     /// provided by `Stepper`'s abstract interface.
-    pub fn inner_mut(&mut self) -> &mut T {
+    pub fn inner_mut(&mut self) -> &mut Driver {
         &mut self.inner
     }
 
     /// Release the wrapped driver
     ///
     /// Drops this instance of `Stepper` and returns the wrapped driver.
-    pub fn release(self) -> T {
+    pub fn release(self) -> Driver {
         self.inner
     }
 
@@ -123,18 +123,18 @@ impl<T> Stepper<T> {
     pub fn enable_step_mode_control<Resources, Timer>(
         self,
         res: Resources,
-        initial: <T::WithStepModeControl as SetStepMode>::StepMode,
+        initial: <Driver::WithStepModeControl as SetStepMode>::StepMode,
         timer: &mut Timer,
     ) -> Result<
-        Stepper<T::WithStepModeControl>,
+        Stepper<Driver::WithStepModeControl>,
         Error<
-            <T::WithStepModeControl as SetStepMode>::Error,
+            <Driver::WithStepModeControl as SetStepMode>::Error,
             <Timer::Time as TryFrom<Nanoseconds>>::Error,
             Timer::Error,
         >,
     >
     where
-        T: EnableStepModeControl<Resources>,
+        Driver: EnableStepModeControl<Resources>,
         Timer: timer::CountDown,
         Timer::Time: TryFrom<Nanoseconds>,
     {
@@ -157,11 +157,11 @@ impl<T> Stepper<T> {
     /// this method available.
     pub fn set_step_mode<'r, Timer>(
         &'r mut self,
-        step_mode: T::StepMode,
+        step_mode: Driver::StepMode,
         timer: &'r mut Timer,
-    ) -> SetStepModeFuture<'r, T, Timer>
+    ) -> SetStepModeFuture<'r, Driver, Timer>
     where
-        T: SetStepMode,
+        Driver: SetStepMode,
         Timer: timer::CountDown,
         Timer::Time: TryFrom<Nanoseconds>,
     {
@@ -188,15 +188,15 @@ impl<T> Stepper<T> {
         initial: Direction,
         timer: &mut Timer,
     ) -> Result<
-        Stepper<T::WithDirectionControl>,
+        Stepper<Driver::WithDirectionControl>,
         Error<
-            <T::WithDirectionControl as SetDirection>::Error,
+            <Driver::WithDirectionControl as SetDirection>::Error,
             <Timer::Time as TryFrom<Nanoseconds>>::Error,
             Timer::Error,
         >,
     >
     where
-        T: EnableDirectionControl<Resources>,
+        Driver: EnableDirectionControl<Resources>,
         Timer: timer::CountDown,
         Timer::Time: TryFrom<Nanoseconds>,
     {
@@ -216,9 +216,9 @@ impl<T> Stepper<T> {
         &'r mut self,
         direction: Direction,
         timer: &'r mut Timer,
-    ) -> SetDirectionFuture<'r, T, Timer>
+    ) -> SetDirectionFuture<'r, Driver, Timer>
     where
-        T: SetDirection,
+        Driver: SetDirection,
         Timer: timer::CountDown,
         Timer::Time: TryFrom<Nanoseconds>,
     {
@@ -242,9 +242,9 @@ impl<T> Stepper<T> {
     pub fn enable_step_control<Resources>(
         self,
         res: Resources,
-    ) -> Stepper<T::WithStepControl>
+    ) -> Stepper<Driver::WithStepControl>
     where
-        T: EnableStepControl<Resources>,
+        Driver: EnableStepControl<Resources>,
     {
         Stepper {
             inner: self.inner.enable_step_control(res),
@@ -262,9 +262,9 @@ impl<T> Stepper<T> {
     pub fn step<'r, Timer>(
         &'r mut self,
         timer: &'r mut Timer,
-    ) -> StepFuture<'r, T, Timer>
+    ) -> StepFuture<'r, Driver, Timer>
     where
-        T: Step,
+        Driver: Step,
         Timer: timer::CountDown,
         Timer::Time: TryFrom<Nanoseconds>,
     {
@@ -280,9 +280,9 @@ impl<T> Stepper<T> {
     /// method available.
     pub fn pulse_length(&self) -> Nanoseconds
     where
-        T: Step,
+        Driver: Step,
     {
-        T::PULSE_LENGTH
+        Driver::PULSE_LENGTH
     }
 }
 

--- a/src/stepper/mod.rs
+++ b/src/stepper/mod.rs
@@ -74,13 +74,13 @@ use crate::{
 /// [RFC 2632]: https://github.com/rust-lang/rfcs/pull/2632
 /// [RFC 2920]: https://github.com/rust-lang/rfcs/pull/2920
 pub struct Stepper<Driver> {
-    inner: Driver,
+    driver: Driver,
 }
 
 impl<Driver> Stepper<Driver> {
     /// Create a new `Stepper` instance from a driver
-    pub fn from_inner(inner: Driver) -> Self {
-        Self { inner }
+    pub fn from_inner(driver: Driver) -> Self {
+        Self { driver }
     }
 
     /// Access a reference to the wrapped driver
@@ -88,7 +88,7 @@ impl<Driver> Stepper<Driver> {
     /// Can be used to access driver-specific functionality that can't be
     /// provided by `Stepper`'s abstract interface.
     pub fn inner(&self) -> &Driver {
-        &self.inner
+        &self.driver
     }
 
     /// Access a mutable reference to the wrapped driver or controller
@@ -96,14 +96,14 @@ impl<Driver> Stepper<Driver> {
     /// Can be used to access driver-specific functionality that can't be
     /// provided by `Stepper`'s abstract interface.
     pub fn inner_mut(&mut self) -> &mut Driver {
-        &mut self.inner
+        &mut self.driver
     }
 
     /// Release the wrapped driver
     ///
     /// Drops this instance of `Stepper` and returns the wrapped driver.
     pub fn release(self) -> Driver {
-        self.inner
+        self.driver
     }
 
     /// Enable microstepping mode control
@@ -139,7 +139,7 @@ impl<Driver> Stepper<Driver> {
         Timer::Time: TryFrom<Nanoseconds>,
     {
         let mut self_ = Stepper {
-            inner: self.inner.enable_step_mode_control(res),
+            driver: self.driver.enable_step_mode_control(res),
         };
         self_.set_step_mode(initial, timer).wait()?;
 
@@ -201,7 +201,7 @@ impl<Driver> Stepper<Driver> {
         Timer::Time: TryFrom<Nanoseconds>,
     {
         let mut self_ = Stepper {
-            inner: self.inner.enable_direction_control(res),
+            driver: self.driver.enable_direction_control(res),
         };
         self_.set_direction(initial, timer).wait()?;
 
@@ -247,7 +247,7 @@ impl<Driver> Stepper<Driver> {
         Driver: EnableStepControl<Resources>,
     {
         Stepper {
-            inner: self.inner.enable_step_control(res),
+            driver: self.driver.enable_step_control(res),
         }
     }
 

--- a/src/stepper/mod.rs
+++ b/src/stepper/mod.rs
@@ -87,7 +87,7 @@ impl<Driver> Stepper<Driver> {
     ///
     /// Can be used to access driver-specific functionality that can't be
     /// provided by `Stepper`'s abstract interface.
-    pub fn inner(&self) -> &Driver {
+    pub fn driver(&self) -> &Driver {
         &self.driver
     }
 
@@ -95,7 +95,7 @@ impl<Driver> Stepper<Driver> {
     ///
     /// Can be used to access driver-specific functionality that can't be
     /// provided by `Stepper`'s abstract interface.
-    pub fn inner_mut(&mut self) -> &mut Driver {
+    pub fn driver_mut(&mut self) -> &mut Driver {
         &mut self.driver
     }
 

--- a/src/stepper/mod.rs
+++ b/src/stepper/mod.rs
@@ -20,11 +20,29 @@ use crate::{
     Direction,
 };
 
-/// Abstract interface to stepper motors
+/// Unified stepper motor interface
 ///
-/// Wraps a concrete stepper driver or controller, and uses the traits that this
-/// concrete driver or controller implements to provide an abstract API. You can
-/// construct an instance of this type using [`Stepper::from_inner`].
+/// Wraps a driver that interfaces with the motor-controlling hardware and
+/// abstracts over it, providing an interface that works the same, no matter
+/// what kind of hardware controls the stepper motor.
+///
+/// You can construct an instance of this type using [`Stepper::from_inner`].
+///
+/// # Nomenclature
+///
+/// This structs wraps a software component that interfaces with hardware that
+/// controls a stepper motor. That software component is called a "driver",
+/// because it "drives" the hardware it interfaces with.
+///
+/// The driven hardware typically comes in two forms:
+///
+/// - A low-level chip controlled by STEP and DIR signals, often called a
+//    stepper driver (yes, somewhat confusing) or stepper controller.
+/// - A higher-level chip, typically controlled through some serial interface,
+///   often called a motion controller.
+///
+/// In practice, a given product can cleanly fall into one of the two camps,
+/// both, or anything in between.
 ///
 /// # Notes on timer use
 ///
@@ -60,31 +78,30 @@ pub struct Stepper<T> {
 }
 
 impl<T> Stepper<T> {
-    /// Create a new `Stepper` instance from a concrete driver or controller
+    /// Create a new `Stepper` instance from a driver
     pub fn from_inner(inner: T) -> Self {
         Self { inner }
     }
 
-    /// Access a reference to the wrapped driver or controller
+    /// Access a reference to the wrapped driver
     ///
-    /// Can be used to access driver/controller-specific functionality that
-    /// can't be provided by `Stepper`'s abstract interface.
+    /// Can be used to access driver-specific functionality that can't be
+    /// provided by `Stepper`'s abstract interface.
     pub fn inner(&self) -> &T {
         &self.inner
     }
 
     /// Access a mutable reference to the wrapped driver or controller
     ///
-    /// Can be used to access driver/controller-specific functionality that
-    /// can't be provided by `Stepper`'s abstract interface.
+    /// Can be used to access driver-specific functionality that can't be
+    /// provided by `Stepper`'s abstract interface.
     pub fn inner_mut(&mut self) -> &mut T {
         &mut self.inner
     }
 
-    /// Release the wrapped driver or controller
+    /// Release the wrapped driver
     ///
-    /// Drops this instance of `Stepper` and returns the wrapped driver/
-    /// controller.
+    /// Drops this instance of `Stepper` and returns the wrapped driver.
     pub fn release(self) -> T {
         self.inner
     }
@@ -97,12 +114,12 @@ impl<T> Stepper<T> {
     ///
     /// Takes the hardware resources that are required for controlling the
     /// microstepping mode as an argument. What exactly those are depends on the
-    /// specific driver/controller. Typically they are the output pins that are
-    /// connected to the mode pins of the driver/controller.
+    /// specific driver. Typically they are the output pins that are connected
+    /// to the mode pins of the driver.
     ///
-    /// This method is only available, if the driver/controller supports
-    /// enabling step mode control. It might no longer be available, once step
-    /// mode control has been enabled.
+    /// This method is only available, if the driver supports enabling step mode
+    /// control. It might no longer be available, once step mode control has
+    /// been enabled.
     pub fn enable_step_mode_control<Resources, Timer>(
         self,
         res: Resources,
@@ -131,10 +148,10 @@ impl<T> Stepper<T> {
 
     /// Sets the microstepping mode
     ///
-    /// This method is only available, if the wrapped driver/controller supports
+    /// This method is only available, if the wrapped driver supports
     /// microstepping, and supports setting the step mode through software. Some
-    /// drivers/controllers might not support microstepping at all, or only
-    /// allow setting the step mode by changing physical switches.
+    /// hardware might not support microstepping at all, or only allow setting
+    /// the step mode by changing physical switches.
     ///
     /// You might need to call [`Stepper::enable_step_mode_control`] to make
     /// this method available.
@@ -159,12 +176,12 @@ impl<T> Stepper<T> {
     ///
     /// Takes the hardware resources that are required for controlling the
     /// direction as an argument. What exactly those are depends on the specific
-    /// driver/controller. Typically it's going to be the output pin that is
-    /// connected to the driver/controller's DIR pin.
+    /// driver. Typically it's going to be the output pin that is connected to
+    /// the hardware's DIR pin.
     ///
-    /// This method is only available, if the driver/controller supports
-    /// enabling direction control. It might no longer be available, once
-    /// direction control has been enabled.
+    /// This method is only available, if the driver supports enabling direction
+    /// control. It might no longer be available, once direction control has
+    /// been enabled.
     pub fn enable_direction_control<Resources, Timer>(
         self,
         res: Resources,
@@ -216,8 +233,8 @@ impl<T> Stepper<T> {
     ///
     /// Takes the hardware resources that are required for controlling the
     /// direction as an argument. What exactly those are depends on the specific
-    /// driver/controller. Typically it's going to be the output pin that is
-    /// connected to the driver/controller's STEP pin.
+    /// driver. Typically it's going to be the output pin that is connected to
+    /// the hardware's STEP pin.
     ///
     /// This method is only available, if the driver/controller supports
     /// enabling step control. It might no longer be available, once step

--- a/src/stepper/mod.rs
+++ b/src/stepper/mod.rs
@@ -26,7 +26,7 @@ use crate::{
 /// abstracts over it, providing an interface that works the same, no matter
 /// what kind of hardware controls the stepper motor.
 ///
-/// You can construct an instance of this type using [`Stepper::from_inner`].
+/// You can construct an instance of this type using [`Stepper::from_driver`].
 ///
 /// # Nomenclature
 ///
@@ -79,7 +79,7 @@ pub struct Stepper<Driver> {
 
 impl<Driver> Stepper<Driver> {
     /// Create a new `Stepper` instance from a driver
-    pub fn from_inner(driver: Driver) -> Self {
+    pub fn from_driver(driver: Driver) -> Self {
         Self { driver }
     }
 

--- a/src/stepper/set_direction.rs
+++ b/src/stepper/set_direction.rs
@@ -69,13 +69,13 @@ where
                 match self.direction {
                     Direction::Forward => self
                         .stepper
-                        .inner
+                        .driver
                         .dir()
                         .try_set_high()
                         .map_err(|err| Error::Pin(err))?,
                     Direction::Backward => self
                         .stepper
-                        .inner
+                        .driver
                         .dir()
                         .try_set_low()
                         .map_err(|err| Error::Pin(err))?,

--- a/src/stepper/set_direction.rs
+++ b/src/stepper/set_direction.rs
@@ -15,22 +15,22 @@ use super::{Error, Stepper};
 /// Please note that this type provides a custom API and does not implement
 /// [`core::future::Future`]. This might change, as using futures for embedded
 /// development becomes more practical.
-pub struct SetDirectionFuture<'r, T, Timer> {
+pub struct SetDirectionFuture<'r, Driver, Timer> {
     direction: Direction,
-    stepper: &'r mut Stepper<T>,
+    stepper: &'r mut Stepper<Driver>,
     timer: &'r mut Timer,
     state: State,
 }
 
-impl<'r, T, Timer> SetDirectionFuture<'r, T, Timer>
+impl<'r, Driver, Timer> SetDirectionFuture<'r, Driver, Timer>
 where
-    T: SetDirection,
+    Driver: SetDirection,
     Timer: timer::CountDown,
     Timer::Time: TryFrom<Nanoseconds>,
 {
     pub(super) fn new(
         direction: Direction,
-        stepper: &'r mut Stepper<T>,
+        stepper: &'r mut Stepper<Driver>,
         timer: &'r mut Timer,
     ) -> Self {
         Self {
@@ -58,7 +58,7 @@ where
         Result<
             (),
             Error<
-                T::Error,
+                Driver::Error,
                 <Timer::Time as TryFrom<Nanoseconds>>::Error,
                 Timer::Error,
             >,
@@ -81,7 +81,7 @@ where
                         .map_err(|err| Error::Pin(err))?,
                 }
 
-                let ticks: Timer::Time = T::SETUP_TIME
+                let ticks: Timer::Time = Driver::SETUP_TIME
                     .try_into()
                     .map_err(|err| Error::TimeConversion(err))?;
                 self.timer
@@ -115,7 +115,7 @@ where
     ) -> Result<
         (),
         Error<
-            T::Error,
+            Driver::Error,
             <Timer::Time as TryFrom<Nanoseconds>>::Error,
             Timer::Error,
         >,

--- a/src/stepper/set_step_mode.rs
+++ b/src/stepper/set_step_mode.rs
@@ -67,7 +67,7 @@ where
         match self.state {
             State::Initial => {
                 self.stepper
-                    .inner
+                    .driver
                     .apply_mode_config(self.step_mode)
                     .map_err(|err| Error::Pin(err))?;
 
@@ -84,7 +84,7 @@ where
             State::ApplyingConfig => match self.timer.try_wait() {
                 Ok(()) => {
                     self.stepper
-                        .inner
+                        .driver
                         .enable_driver()
                         .map_err(|err| Error::Pin(err))?;
 

--- a/src/stepper/set_step_mode.rs
+++ b/src/stepper/set_step_mode.rs
@@ -15,22 +15,22 @@ use super::{Error, Stepper};
 /// Please note that this type provides a custom API and does not implement
 /// [`core::future::Future`]. This might change, as using futures for embedded
 /// development becomes more practical.
-pub struct SetStepModeFuture<'r, T: SetStepMode, Timer> {
-    step_mode: T::StepMode,
-    stepper: &'r mut Stepper<T>,
+pub struct SetStepModeFuture<'r, Driver: SetStepMode, Timer> {
+    step_mode: Driver::StepMode,
+    stepper: &'r mut Stepper<Driver>,
     timer: &'r mut Timer,
     state: State,
 }
 
-impl<'r, T, Timer> SetStepModeFuture<'r, T, Timer>
+impl<'r, Driver, Timer> SetStepModeFuture<'r, Driver, Timer>
 where
-    T: SetStepMode,
+    Driver: SetStepMode,
     Timer: timer::CountDown,
     Timer::Time: TryFrom<Nanoseconds>,
 {
     pub(super) fn new(
-        step_mode: T::StepMode,
-        stepper: &'r mut Stepper<T>,
+        step_mode: Driver::StepMode,
+        stepper: &'r mut Stepper<Driver>,
         timer: &'r mut Timer,
     ) -> Self {
         Self {
@@ -58,7 +58,7 @@ where
         Result<
             (),
             Error<
-                T::Error,
+                Driver::Error,
                 <Timer::Time as TryFrom<Nanoseconds>>::Error,
                 Timer::Error,
             >,
@@ -71,7 +71,7 @@ where
                     .apply_mode_config(self.step_mode)
                     .map_err(|err| Error::Pin(err))?;
 
-                let ticks: Timer::Time = T::SETUP_TIME
+                let ticks: Timer::Time = Driver::SETUP_TIME
                     .try_into()
                     .map_err(|err| Error::TimeConversion(err))?;
                 self.timer
@@ -88,7 +88,7 @@ where
                         .enable_driver()
                         .map_err(|err| Error::Pin(err))?;
 
-                    let ticks: Timer::Time = T::HOLD_TIME
+                    let ticks: Timer::Time = Driver::HOLD_TIME
                         .try_into()
                         .map_err(|err| Error::TimeConversion(err))?;
                     self.timer
@@ -129,7 +129,7 @@ where
     ) -> Result<
         (),
         Error<
-            T::Error,
+            Driver::Error,
             <Timer::Time as TryFrom<Nanoseconds>>::Error,
             Timer::Error,
         >,

--- a/src/stepper/step.rs
+++ b/src/stepper/step.rs
@@ -65,7 +65,7 @@ where
             State::Initial => {
                 // Start step pulse
                 self.stepper
-                    .inner
+                    .driver
                     .step()
                     .try_set_high()
                     .map_err(|err| Error::Pin(err))?;
@@ -85,7 +85,7 @@ where
                     Ok(()) => {
                         // End step pulse
                         self.stepper
-                            .inner
+                            .driver
                             .step()
                             .try_set_low()
                             .map_err(|err| Error::Pin(err))?;

--- a/src/stepper/step.rs
+++ b/src/stepper/step.rs
@@ -15,20 +15,20 @@ use super::{Error, Stepper};
 /// Please note that this type provides a custom API and does not implement
 /// [`core::future::Future`]. This might change, as using futures for embedded
 /// development becomes more practical.
-pub struct StepFuture<'r, T, Timer> {
-    stepper: &'r mut Stepper<T>,
+pub struct StepFuture<'r, Driver, Timer> {
+    stepper: &'r mut Stepper<Driver>,
     timer: &'r mut Timer,
     state: State,
 }
 
-impl<'r, T, Timer> StepFuture<'r, T, Timer>
+impl<'r, Driver, Timer> StepFuture<'r, Driver, Timer>
 where
-    T: Step,
+    Driver: Step,
     Timer: timer::CountDown,
     Timer::Time: TryFrom<Nanoseconds>,
 {
     pub(super) fn new(
-        stepper: &'r mut Stepper<T>,
+        stepper: &'r mut Stepper<Driver>,
         timer: &'r mut Timer,
     ) -> Self {
         Self {
@@ -55,7 +55,7 @@ where
         Result<
             (),
             Error<
-                T::Error,
+                Driver::Error,
                 <Timer::Time as TryFrom<Nanoseconds>>::Error,
                 Timer::Error,
             >,
@@ -70,7 +70,7 @@ where
                     .try_set_high()
                     .map_err(|err| Error::Pin(err))?;
 
-                let ticks: Timer::Time = T::PULSE_LENGTH
+                let ticks: Timer::Time = Driver::PULSE_LENGTH
                     .try_into()
                     .map_err(|err| Error::TimeConversion(err))?;
                 self.timer
@@ -113,7 +113,7 @@ where
     ) -> Result<
         (),
         Error<
-            T::Error,
+            Driver::Error,
             <Timer::Time as TryFrom<Nanoseconds>>::Error,
             Timer::Error,
         >,

--- a/test-stand/tests/tests/stspin220.rs
+++ b/test-stand/tests/tests/stspin220.rs
@@ -86,7 +86,7 @@ mod tests {
 
         let mut timer = mrt.mrt0;
 
-        let stepper = Stepper::from_inner(STSPIN220::new())
+        let stepper = Stepper::from_driver(STSPIN220::new())
             .enable_step_control(step_mode3)
             .enable_direction_control(dir_mode4, Direction::Forward, &mut timer)
             .unwrap()


### PR DESCRIPTION
Establishes a consistent nomenclature, and updates documentation, method names etc. accordingly. This is more fallout from #83.