### PR TITLE
Add constructor to convert velocity to `Direction`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,10 @@ embedded-time = "0.10.1"
 nb            = "1.0.0"
 paste         = "1.0.3"
 
+[dependencies.num-traits]
+version          = "0.2.14"
+default-features = false
+
 [features]
 default = ["drv8825", "stspin220"]
 drv8825 = []

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -155,3 +155,21 @@ pub enum Direction {
     /// driver's DIR signal set is LOW.
     Backward = -1,
 }
+
+impl Direction {
+    /// Create a `Direction` from a velocity value
+    ///
+    /// Expects the velocity value to be signed. Zero or a positive value will
+    /// result in forward direction, a negative value will result in backward
+    /// direction.
+    pub fn from_velocity<Velocity>(velocity: Velocity) -> Self
+    where
+        Velocity: num_traits::Signed,
+    {
+        if velocity.is_negative() {
+            Self::Backward
+        } else {
+            Self::Forward
+        }
+    }
+}


### PR DESCRIPTION
I'm going to need this in an upcoming pull request I'm currently working
on, but it seems like a reasonable addition on its own.