### PR TITLE
Make futures more flexible

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -135,6 +135,7 @@ pub extern crate embedded_time;
 pub mod drivers;
 pub mod step_mode;
 pub mod traits;
+pub mod util;
 
 mod stepper;
 

--- a/src/stepper/mod.rs
+++ b/src/stepper/mod.rs
@@ -17,6 +17,7 @@ use crate::{
         EnableDirectionControl, EnableStepControl, EnableStepModeControl,
         SetDirection, SetStepMode, Step,
     },
+    util::ref_mut::RefMut,
     Direction,
 };
 
@@ -191,13 +192,17 @@ impl<Driver> Stepper<Driver> {
         &'r mut self,
         step_mode: Driver::StepMode,
         timer: &'r mut Timer,
-    ) -> SetStepModeFuture<'r, Driver, Timer>
+    ) -> SetStepModeFuture<RefMut<'r, Driver>, RefMut<'r, Timer>>
     where
         Driver: SetStepMode,
         Timer: timer::CountDown,
         Timer::Time: TryFrom<Nanoseconds>,
     {
-        SetStepModeFuture::new(step_mode, &mut self.driver, timer)
+        SetStepModeFuture::new(
+            step_mode,
+            RefMut(&mut self.driver),
+            RefMut(timer),
+        )
     }
 
     /// Enable direction control
@@ -248,13 +253,17 @@ impl<Driver> Stepper<Driver> {
         &'r mut self,
         direction: Direction,
         timer: &'r mut Timer,
-    ) -> SetDirectionFuture<'r, Driver, Timer>
+    ) -> SetDirectionFuture<RefMut<'r, Driver>, RefMut<'r, Timer>>
     where
         Driver: SetDirection,
         Timer: timer::CountDown,
         Timer::Time: TryFrom<Nanoseconds>,
     {
-        SetDirectionFuture::new(direction, &mut self.driver, timer)
+        SetDirectionFuture::new(
+            direction,
+            RefMut(&mut self.driver),
+            RefMut(timer),
+        )
     }
 
     /// Enable step control
@@ -294,13 +303,13 @@ impl<Driver> Stepper<Driver> {
     pub fn step<'r, Timer>(
         &'r mut self,
         timer: &'r mut Timer,
-    ) -> StepFuture<'r, Driver, Timer>
+    ) -> StepFuture<RefMut<'r, Driver>, RefMut<'r, Timer>>
     where
         Driver: Step,
         Timer: timer::CountDown,
         Timer::Time: TryFrom<Nanoseconds>,
     {
-        StepFuture::new(&mut self.driver, timer)
+        StepFuture::new(RefMut(&mut self.driver), RefMut(timer))
     }
 
     /// Returns the step pulse length of the wrapped driver/controller

--- a/src/stepper/set_direction.rs
+++ b/src/stepper/set_direction.rs
@@ -17,14 +17,14 @@ use super::Error;
 /// development becomes more practical.
 ///
 /// [`Stepper::set_direction`]: crate::Stepper::set_direction
-pub struct SetDirectionFuture<'r, Driver, Timer> {
+pub struct SetDirectionFuture<Driver, Timer> {
     direction: Direction,
-    driver: &'r mut Driver,
-    timer: &'r mut Timer,
+    driver: Driver,
+    timer: Timer,
     state: State,
 }
 
-impl<'r, Driver, Timer> SetDirectionFuture<'r, Driver, Timer>
+impl<Driver, Timer> SetDirectionFuture<Driver, Timer>
 where
     Driver: SetDirection,
     Timer: timer::CountDown,
@@ -37,11 +37,7 @@ where
     /// [`Stepper::set_direction`] instead.
     ///
     /// [`Stepper::set_direction`]: crate::Stepper::set_direction
-    pub fn new(
-        direction: Direction,
-        driver: &'r mut Driver,
-        timer: &'r mut Timer,
-    ) -> Self {
+    pub fn new(direction: Direction, driver: Driver, timer: Timer) -> Self {
         Self {
             direction,
             driver,

--- a/src/stepper/set_direction.rs
+++ b/src/stepper/set_direction.rs
@@ -129,6 +129,11 @@ where
             }
         }
     }
+
+    /// Drop the future and release the resources that were moved into it
+    pub fn release(self) -> (Driver, Timer) {
+        (self.driver, self.timer)
+    }
 }
 
 enum State {

--- a/src/stepper/set_step_mode.rs
+++ b/src/stepper/set_step_mode.rs
@@ -17,14 +17,14 @@ use super::Error;
 /// development becomes more practical.
 ///
 /// [`Stepper::set_step_mode`]: crate::Stepper::set_step_mode
-pub struct SetStepModeFuture<'r, Driver: SetStepMode, Timer> {
+pub struct SetStepModeFuture<Driver: SetStepMode, Timer> {
     step_mode: Driver::StepMode,
-    driver: &'r mut Driver,
-    timer: &'r mut Timer,
+    driver: Driver,
+    timer: Timer,
     state: State,
 }
 
-impl<'r, Driver, Timer> SetStepModeFuture<'r, Driver, Timer>
+impl<Driver, Timer> SetStepModeFuture<Driver, Timer>
 where
     Driver: SetStepMode,
     Timer: timer::CountDown,
@@ -39,8 +39,8 @@ where
     /// [`Stepper::set_step_mode`]: crate::Stepper::set_step_mode
     pub fn new(
         step_mode: Driver::StepMode,
-        driver: &'r mut Driver,
-        timer: &'r mut Timer,
+        driver: Driver,
+        timer: Timer,
     ) -> Self {
         Self {
             step_mode,

--- a/src/stepper/set_step_mode.rs
+++ b/src/stepper/set_step_mode.rs
@@ -147,6 +147,11 @@ where
             }
         }
     }
+
+    /// Drop the future and release the resources that were moved into it
+    pub fn release(self) -> (Driver, Timer) {
+        (self.driver, self.timer)
+    }
 }
 
 enum State {

--- a/src/stepper/step.rs
+++ b/src/stepper/step.rs
@@ -17,13 +17,13 @@ use super::Error;
 /// development becomes more practical.
 ///
 /// [`Stepper::step`]: crate::Stepper::step
-pub struct StepFuture<'r, Driver, Timer> {
-    driver: &'r mut Driver,
-    timer: &'r mut Timer,
+pub struct StepFuture<Driver, Timer> {
+    driver: Driver,
+    timer: Timer,
     state: State,
 }
 
-impl<'r, Driver, Timer> StepFuture<'r, Driver, Timer>
+impl<Driver, Timer> StepFuture<Driver, Timer>
 where
     Driver: Step,
     Timer: timer::CountDown,
@@ -36,7 +36,7 @@ where
     /// [`Stepper::step`] instead.
     ///
     /// [`Stepper::step`]: crate::Stepper::step
-    pub fn new(driver: &'r mut Driver, timer: &'r mut Timer) -> Self {
+    pub fn new(driver: Driver, timer: Timer) -> Self {
         Self {
             driver,
             timer,

--- a/src/stepper/step.rs
+++ b/src/stepper/step.rs
@@ -128,6 +128,11 @@ where
             }
         }
     }
+
+    /// Drop the future and release the resources that were moved into it
+    pub fn release(self) -> (Driver, Timer) {
+        (self.driver, self.timer)
+    }
 }
 
 enum State {

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -1,0 +1,3 @@
+//! Utility module for miscellaneous stuff that the rest of the crate needs
+
+pub mod ref_mut;

--- a/src/util/ref_mut.rs
+++ b/src/util/ref_mut.rs
@@ -1,0 +1,88 @@
+//! Generic wrapper around a mutable reference
+//!
+//! See [`RefMut`] for more information.
+
+use embedded_hal::timer;
+use embedded_time::duration::Nanoseconds;
+
+use crate::traits::{SetDirection, SetStepMode, Step};
+
+/// Generic wrapper around a mutable reference
+///
+/// This is used as a means of implementing traits that are already implemented
+/// for `T` for `&mut T` too. While this is redundant for the traits from this
+/// crate, we couldn't do this for `embedded_hal::timer::CountDown` without a
+/// crate-local type.
+///
+/// The purpose of this is to make the future types more flexible, making it
+/// possible to move types into them, or just provide mutable references.
+pub struct RefMut<'r, T>(pub &'r mut T);
+
+impl<'r, T> timer::CountDown for RefMut<'r, T>
+where
+    T: timer::CountDown,
+{
+    type Error = T::Error;
+    type Time = T::Time;
+
+    fn try_start<Time>(&mut self, count: Time) -> Result<(), Self::Error>
+    where
+        Time: Into<Self::Time>,
+    {
+        self.0.try_start(count)
+    }
+
+    fn try_wait(&mut self) -> nb::Result<(), Self::Error> {
+        self.0.try_wait()
+    }
+}
+
+impl<'r, T> SetDirection for RefMut<'r, T>
+where
+    T: SetDirection,
+{
+    const SETUP_TIME: Nanoseconds = T::SETUP_TIME;
+
+    type Dir = T::Dir;
+    type Error = T::Error;
+
+    fn dir(&mut self) -> &mut Self::Dir {
+        self.0.dir()
+    }
+}
+
+impl<'r, T> SetStepMode for RefMut<'r, T>
+where
+    T: SetStepMode,
+{
+    const SETUP_TIME: Nanoseconds = T::SETUP_TIME;
+    const HOLD_TIME: Nanoseconds = T::HOLD_TIME;
+
+    type Error = T::Error;
+    type StepMode = T::StepMode;
+
+    fn apply_mode_config(
+        &mut self,
+        step_mode: Self::StepMode,
+    ) -> Result<(), Self::Error> {
+        self.0.apply_mode_config(step_mode)
+    }
+
+    fn enable_driver(&mut self) -> Result<(), Self::Error> {
+        self.0.enable_driver()
+    }
+}
+
+impl<'r, T> Step for RefMut<'r, T>
+where
+    T: Step,
+{
+    const PULSE_LENGTH: Nanoseconds = T::PULSE_LENGTH;
+
+    type Step = T::Step;
+    type Error = T::Error;
+
+    fn step(&mut self) -> &mut Self::Step {
+        self.0.step()
+    }
+}


### PR DESCRIPTION
I'm working on a higher-level API that should be implementable for motion control chips, but also have a software fallback for regular STEP/DIR drivers. In implementing this software fallback, I find the need to re-use parts of `Stepper` (for architectural reasons, I can't use the `Stepper` API in this fallback implementation).

This series of commits makes the API of the future types more flexible, so I can re-use them in the motion control fallback implementation.