### PR TITLE
Make futures `#[must_use]`

### DIFF
--- a/src/stepper/set_direction.rs
+++ b/src/stepper/set_direction.rs
@@ -17,6 +17,7 @@ use super::Error;
 /// development becomes more practical.
 ///
 /// [`Stepper::set_direction`]: crate::Stepper::set_direction
+#[must_use]
 pub struct SetDirectionFuture<Driver, Timer> {
     direction: Direction,
     driver: Driver,

--- a/src/stepper/set_step_mode.rs
+++ b/src/stepper/set_step_mode.rs
@@ -17,6 +17,7 @@ use super::Error;
 /// development becomes more practical.
 ///
 /// [`Stepper::set_step_mode`]: crate::Stepper::set_step_mode
+#[must_use]
 pub struct SetStepModeFuture<Driver: SetStepMode, Timer> {
     step_mode: Driver::StepMode,
     driver: Driver,

--- a/src/stepper/step.rs
+++ b/src/stepper/step.rs
@@ -17,6 +17,7 @@ use super::Error;
 /// development becomes more practical.
 ///
 /// [`Stepper::step`]: crate::Stepper::step
+#[must_use]
 pub struct StepFuture<Driver, Timer> {
     driver: Driver,
     timer: Timer,


### PR DESCRIPTION
Otherwise it's easy to forget them, especially for those unfamiliar with
the API.