### PR TITLE
Add high-level motion control interface

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,15 +27,22 @@ license     = "0BSD"
 keywords    = ["stepper", "motor", "driver", "abstract", "interface"]
 categories  = ["embedded", "hardware-support", "no-std", "science::robotics"]
 
+
 [dependencies]
 embedded-hal  = "=1.0.0-alpha.4"
 embedded-time = "0.10.1"
 nb            = "1.0.0"
 paste         = "1.0.3"
+ramp-maker    = "0.2.0"
 
 [dependencies.num-traits]
 version          = "0.2.14"
 default-features = false
+
+[dependencies.replace_with]
+version          = "0.1.7"
+default-features = false
+
 
 [features]
 default = ["drv8825", "stspin220"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -133,6 +133,7 @@ pub extern crate embedded_hal;
 pub extern crate embedded_time;
 
 pub mod drivers;
+pub mod motion_control;
 pub mod step_mode;
 pub mod traits;
 pub mod util;

--- a/src/motion_control.rs
+++ b/src/motion_control.rs
@@ -1,0 +1,409 @@
+//! Software implementation of motion control capability
+//!
+//! See [`SoftwareMotionControl`] for more information.
+
+use core::{
+    convert::{TryFrom, TryInto},
+    task::Poll,
+};
+
+use embedded_hal::timer;
+use embedded_time::duration::Nanoseconds;
+use num_traits::Signed as _;
+use ramp_maker::MotionProfile;
+use replace_with::replace_with_and_return;
+
+use crate::{
+    traits::{EnableMotionControl, MotionControl, SetDirection, Step},
+    Direction, SetDirectionFuture, StepFuture,
+};
+
+/// Software implementation of motion control capability
+///
+/// Some driver natively support motion control capability. This is a software
+/// implementation of the [`MotionControl`] trait for those drivers that don't.
+/// It wraps a driver that implements [`SetDirection`] and [`Step`], and in turn
+/// acts like a driver itself, adding to the wrapped driver's capabilities.
+///
+/// You can use `SoftwareMotionControl` directly, but like a driver, it is
+/// designed to be used through the [`Stepper`] API.
+///
+/// [`Stepper`]: crate::Stepper
+pub struct SoftwareMotionControl<Driver, Timer, Profile: MotionProfile> {
+    state: State<Driver, Timer, Profile>,
+    new_motion: Option<Direction>,
+    profile: Profile,
+}
+
+impl<Driver, Timer, Profile> SoftwareMotionControl<Driver, Timer, Profile>
+where
+    Profile: MotionProfile,
+{
+    /// Construct a new instance of `SoftwareMotionControl`
+    ///
+    /// Instead of using this constructor directly, you can instead use
+    /// [`Stepper::enable_motion_control`] with any driver that implements
+    /// [`SetDirection`] and [`Step`], providing timer and a motion profile.
+    /// This module provides a blanket implementation of [`EnableMotionControl`]
+    /// to make this work.
+    ///
+    /// [`Stepper::enable_motion_control`]: crate::Stepper::enable_motion_control
+    pub fn new(driver: Driver, timer: Timer, profile: Profile) -> Self {
+        Self {
+            state: State::Idle { driver, timer },
+            new_motion: None,
+            profile,
+        }
+    }
+
+    /// Access a reference to the wrapped driver
+    ///
+    /// This is only possible if there is no ongoing movement.
+    pub fn driver(&self) -> Option<&Driver> {
+        if let State::Idle { driver, .. } = &self.state {
+            return Some(driver);
+        }
+
+        None
+    }
+
+    /// Access a mutable reference to the wrapped driver
+    ///
+    /// This is only possible if there is no ongoing movement.
+    pub fn driver_mut(&mut self) -> Option<&mut Driver> {
+        if let State::Idle { driver, .. } = &mut self.state {
+            return Some(driver);
+        }
+
+        None
+    }
+
+    /// Access a reference to the wrapped timer
+    ///
+    /// This is only possible if there is no ongoing movement.
+    pub fn timer(&self) -> Option<&Timer> {
+        if let State::Idle { timer, .. } = &self.state {
+            return Some(timer);
+        }
+
+        None
+    }
+
+    /// Access a mutable reference to the wrapped timer
+    ///
+    /// This is only possible if there is no ongoing movement.
+    pub fn timer_mut(&mut self) -> Option<&mut Timer> {
+        if let State::Idle { timer, .. } = &mut self.state {
+            return Some(timer);
+        }
+
+        None
+    }
+
+    /// Access a reference to the wrapped motion profile
+    pub fn profile(&self) -> &Profile {
+        &self.profile
+    }
+
+    /// Access a mutable reference to the wrapped motion profile
+    pub fn profile_mut(&mut self) -> &mut Profile {
+        &mut self.profile
+    }
+}
+
+impl<Driver, Timer, Profile> MotionControl
+    for SoftwareMotionControl<Driver, Timer, Profile>
+where
+    Driver: SetDirection + Step,
+    Profile: MotionProfile,
+    Timer: timer::CountDown,
+    Timer::Time: TryFrom<Nanoseconds>,
+    Profile::Delay: TryInto<Nanoseconds>,
+    Profile::Velocity: Copy + num_traits::Signed,
+{
+    type Velocity = Profile::Velocity;
+    type Error = Error<Driver, Timer, Profile>;
+
+    fn move_to_position(
+        &mut self,
+        max_velocity: Self::Velocity,
+        target_step: u32,
+    ) -> Result<(), Self::Error> {
+        self.profile
+            .enter_position_mode(max_velocity.abs(), target_step);
+
+        let direction = Direction::from_velocity(max_velocity);
+        self.new_motion = Some(direction);
+
+        Ok(())
+    }
+
+    fn update(&mut self) -> Result<bool, Self::Error> {
+        // Otherwise the closure will borrow all of `self`.
+        let new_motion = &mut self.new_motion;
+        let profile = &mut self.profile;
+
+        replace_with_and_return(
+            &mut self.state,
+            || State::Invalid,
+            |state| update_state(state, new_motion, profile),
+        )
+    }
+}
+
+enum State<Driver, Timer, Profile: MotionProfile> {
+    Idle {
+        driver: Driver,
+        timer: Timer,
+    },
+    SetDirection(SetDirectionFuture<Driver, Timer>),
+    Step {
+        future: StepFuture<Driver, Timer>,
+        delay: Profile::Delay,
+    },
+    StepDelay {
+        driver: Driver,
+        timer: Timer,
+    },
+    Invalid,
+}
+
+/// An error that can occur while using [`SoftwareMotionControl`]
+pub enum Error<Driver, Timer, Profile>
+where
+    Driver: SetDirection + Step,
+    Timer: timer::CountDown,
+    Profile: MotionProfile,
+    Timer::Time: TryFrom<Nanoseconds>,
+    Profile::Delay: TryInto<Nanoseconds>,
+{
+    /// Error while setting direction
+    SetDirection(
+        crate::Error<
+            <Driver as SetDirection>::Error,
+            <Timer::Time as TryFrom<Nanoseconds>>::Error,
+            Timer::Error,
+        >,
+    ),
+
+    /// Error while stepping the motor
+    Step(
+        crate::Error<
+            <Driver as Step>::Error,
+            <Timer::Time as TryFrom<Nanoseconds>>::Error,
+            Timer::Error,
+        >,
+    ),
+
+    /// Error while converting between time formats
+    TimeConversion(TimeConversionError<Timer::Time, Profile::Delay>),
+
+    /// Error while waiting for a step to finish
+    StepDelay(Timer::Error),
+}
+
+/// An error occurred while converting between time formats
+pub enum TimeConversionError<
+    Time: TryFrom<Nanoseconds>,
+    Delay: TryInto<Nanoseconds>,
+> {
+    /// Error converting from nanoseconds to timer ticks
+    ToTimerTime(Time::Error),
+
+    /// Error converting from timer ticks to nanoseconds
+    FromDelay(Delay::Error),
+}
+
+fn update_state<Driver, Timer, Profile>(
+    mut state: State<Driver, Timer, Profile>,
+    new_motion: &mut Option<Direction>,
+    profile: &mut Profile,
+) -> (
+    Result<bool, Error<Driver, Timer, Profile>>,
+    State<Driver, Timer, Profile>,
+)
+where
+    Driver: SetDirection + Step,
+    Timer: timer::CountDown,
+    Timer::Time: TryFrom<Nanoseconds>,
+    Profile: MotionProfile,
+    Profile::Delay: TryInto<Nanoseconds>,
+{
+    loop {
+        match state {
+            State::Idle { driver, timer } => {
+                // Being idle can mean that there's actually nothing to do, or
+                // it might just be a short breather before more work comes in.
+
+                if let Some(direction) = new_motion.take() {
+                    // A new motion has been started. This might override an
+                    // ongoing one, but it makes no difference here.
+                    //
+                    // Let's update the state, but don't return just yet. We
+                    // have more stuff to do (polling the future).
+                    state = State::SetDirection(SetDirectionFuture::new(
+                        direction, driver, timer,
+                    ));
+                    continue;
+                }
+
+                // No new motion has been started, but we might still have an
+                // ongoing one. Let's ask the motion profile.
+                if let Some(delay) = profile.next_delay() {
+                    // There's a motion ongoing. Let's start the next step, but
+                    // again, don't return yet. The future needs to be polled.
+                    state = State::Step {
+                        future: StepFuture::new(driver, timer),
+                        delay,
+                    };
+                    continue;
+                }
+
+                // Now we know that there's truly nothing to do. Return to the
+                // caller and stay idle.
+                return (Ok(false), State::Idle { driver, timer });
+            }
+            State::SetDirection(mut future) => {
+                match future.poll() {
+                    Poll::Ready(Ok(())) => {
+                        // Direction has been set. Set state back to idle, so we
+                        // can figure out what to do next in the next loop
+                        // iteration.
+                        let (driver, timer) = future.release();
+                        state = State::Idle { driver, timer };
+                        continue;
+                    }
+                    Poll::Ready(Err(err)) => {
+                        // Error happened while setting direction. We need to
+                        // let the caller know.
+                        //
+                        // The state stays as it is. For all we know, the error
+                        // can be recovered from.
+                        return (
+                            Err(Error::SetDirection(err)),
+                            State::SetDirection(future),
+                        );
+                    }
+                    Poll::Pending => {
+                        // Still busy setting direction. Let caller know.
+                        return (Ok(true), State::SetDirection(future));
+                    }
+                }
+            }
+            State::Step { mut future, delay } => {
+                match future.poll() {
+                    Poll::Ready(Ok(())) => {
+                        // A step was made. Now we need to wait out the rest of
+                        // the step delay before we can do something else.
+
+                        let (driver, mut timer) = future.release();
+                        let delay_left: Timer::Time =
+                            match delay_left(delay, Driver::PULSE_LENGTH) {
+                                Ok(delay_left) => delay_left,
+                                Err(err) => {
+                                    return (
+                                        Err(Error::TimeConversion(err)),
+                                        State::Idle { driver, timer },
+                                    )
+                                }
+                            };
+
+                        if let Err(err) = timer.try_start(delay_left) {
+                            return (
+                                Err(Error::StepDelay(err)),
+                                State::Idle { driver, timer },
+                            );
+                        }
+
+                        state = State::StepDelay { driver, timer };
+                        continue;
+                    }
+                    Poll::Ready(Err(err)) => {
+                        // Error happened while stepping. Need to
+                        // let the caller know.
+                        //
+                        // State stays as it is. For all we know,
+                        // the error can be recovered from.
+                        return (
+                            Err(Error::Step(err)),
+                            State::Step { future, delay },
+                        );
+                    }
+                    Poll::Pending => {
+                        // Still stepping. Let caller know.
+                        return (Ok(true), State::Step { future, delay });
+                    }
+                }
+            }
+            State::StepDelay { driver, mut timer } => {
+                match timer.try_wait() {
+                    Ok(()) => {
+                        // We've waited out the step delay. Return to idle
+                        // state, to figure out what's next.
+                        state = State::Idle { driver, timer };
+                        continue;
+                    }
+                    Err(nb::Error::WouldBlock) => {
+                        // The timer is still running. Let the user know.
+                        return (Ok(true), State::StepDelay { driver, timer });
+                    }
+                    Err(nb::Error::Other(err)) => {
+                        // Error while trying to wait. Need to tell the caller.
+                        return (
+                            Err(Error::StepDelay(err)),
+                            State::StepDelay { driver, timer },
+                        );
+                    }
+                }
+            }
+            State::Invalid => {
+                // This can only happen if this closure panics, the
+                // user catches the panic, then attempts to
+                // continue.
+                //
+                // A panic in this closure is always going to be a
+                // bug, and once that happened, we're in an invalid
+                // state. Not a lot we can do about it.
+                panic!("Invalid internal state, caused by a previous panic.")
+            }
+        }
+    }
+}
+
+fn delay_left<Delay, Time>(
+    delay: Delay,
+    pulse_length: Nanoseconds,
+) -> Result<Time, TimeConversionError<Time, Delay>>
+where
+    Time: TryFrom<Nanoseconds>,
+    Delay: TryInto<Nanoseconds>,
+{
+    let delay: Nanoseconds = delay
+        .try_into()
+        .map_err(|err| TimeConversionError::FromDelay(err))?;
+    let delay_left: Time = (delay - pulse_length)
+        .try_into()
+        .map_err(|err| TimeConversionError::ToTimerTime(err))?;
+    Ok(delay_left)
+}
+
+// Blanket implementation of `EnableMotionControl` for all STEP/DIR stepper
+// drivers.
+impl<Driver, Timer, Profile> EnableMotionControl<(Timer, Profile)> for Driver
+where
+    Driver: SetDirection + Step,
+    Profile: MotionProfile,
+    Timer: timer::CountDown,
+    Timer::Time: TryFrom<Nanoseconds>,
+    Profile::Delay: TryInto<Nanoseconds>,
+    Profile::Velocity: Copy + num_traits::Signed,
+{
+    type WithMotionControl = SoftwareMotionControl<Driver, Timer, Profile>;
+
+    fn enable_motion_control(
+        self,
+        (timer, profile): (Timer, Profile),
+    ) -> Self::WithMotionControl {
+        SoftwareMotionControl::new(self, timer, profile)
+    }
+}

--- a/src/motion_control.rs
+++ b/src/motion_control.rs
@@ -4,6 +4,7 @@
 
 use core::{
     convert::{TryFrom, TryInto},
+    fmt,
     task::Poll,
 };
 
@@ -202,6 +203,51 @@ where
     StepDelay(Timer::Error),
 }
 
+// Can't `#[derive(Debug)]`, as that can't generate the required trait bounds.
+impl<Driver, Timer, Profile> fmt::Debug for Error<Driver, Timer, Profile>
+where
+    Driver: SetDirection + Step,
+    Timer: timer::CountDown,
+    Profile: MotionProfile,
+    Timer::Time: TryFrom<Nanoseconds>,
+    Profile::Delay: TryInto<Nanoseconds>,
+    <Driver as SetDirection>::Error: fmt::Debug,
+    <Driver as Step>::Error: fmt::Debug,
+    Timer::Error: fmt::Debug,
+    Timer::Time: fmt::Debug,
+    <Timer::Time as TryFrom<Nanoseconds>>::Error: fmt::Debug,
+    Profile::Delay: fmt::Debug,
+    <Profile::Delay as TryInto<Nanoseconds>>::Error: fmt::Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Self::SetDirection(err) => {
+                write!(f, "SetDirection(")?;
+                err.fmt(f)?;
+                write!(f, ")")?;
+            }
+            Self::Step(err) => {
+                write!(f, "Step(")?;
+                err.fmt(f)?;
+                write!(f, ")")?;
+            }
+            Self::TimeConversion(err) => {
+                write!(f, "TimeConversion(")?;
+                err.fmt(f)?;
+                write!(f, ")")?;
+            }
+            Self::StepDelay(err) => {
+                write!(f, "StepDelay(")?;
+                err.fmt(f)?;
+                write!(f, ")")?;
+            }
+        }
+
+        Ok(())
+    }
+}
+
+#[derive(Debug)]
 /// An error occurred while converting between time formats
 pub enum TimeConversionError<
     Time: TryFrom<Nanoseconds>,

--- a/src/stepper/mod.rs
+++ b/src/stepper/mod.rs
@@ -125,7 +125,7 @@ impl<Driver> Stepper<Driver> {
         &self.driver
     }
 
-    /// Access a mutable reference to the wrapped driver or controller
+    /// Access a mutable reference to the wrapped driver
     ///
     /// Can be used to access driver-specific functionality that can't be
     /// provided by `Stepper`'s abstract interface.

--- a/src/stepper/move_to.rs
+++ b/src/stepper/move_to.rs
@@ -1,0 +1,102 @@
+use core::task::Poll;
+
+use crate::traits::MotionControl;
+
+/// The "future" returned by [`Stepper::move_to_position`]
+///
+/// Please note that this type provides a custom API and does not implement
+/// [`core::future::Future`]. This might change, when using futures for embedded
+/// development becomes more practical.
+///
+/// [`Stepper::move_to_position`]: crate::Stepper::move_to_position
+#[must_use]
+pub struct MoveToFuture<Driver: MotionControl> {
+    driver: Driver,
+    state: State<Driver::Velocity>,
+}
+
+impl<Driver> MoveToFuture<Driver>
+where
+    Driver: MotionControl,
+{
+    /// Create new instance of `MoveToFuture`
+    ///
+    /// This constructor is public to provide maximum flexibility for
+    /// non-standard use cases. Most users can ignore this and just use
+    /// [`Stepper::move_to_position`] instead.
+    ///
+    /// [`Stepper::move_to_position`]: crate::Stepper::move_to_position
+    pub fn new(
+        driver: Driver,
+        max_velocity: Driver::Velocity,
+        target_step: u32,
+    ) -> Self {
+        Self {
+            driver,
+            state: State::Initial {
+                max_velocity,
+                target_step,
+            },
+        }
+    }
+
+    /// Poll the future
+    ///
+    /// The future must be polled for the operation to make progress. The
+    /// operation won't start, until this method has been called once. Returns
+    /// [`Poll::Pending`], if the operation is not finished yet, or
+    /// [`Poll::Ready`], once it is.
+    ///
+    /// If this method returns [`Poll::Pending`], the user can opt to keep
+    /// calling it at a high frequency (see [`Self::wait`]) until the operation
+    /// completes, or set up an interrupt that fires once the timer finishes
+    /// counting down, and call this method again once it does.
+    pub fn poll(&mut self) -> Poll<Result<(), Driver::Error>> {
+        match self.state {
+            State::Initial {
+                max_velocity,
+                target_step,
+            } => {
+                self.driver.move_to_position(max_velocity, target_step)?;
+                self.state = State::Moving;
+                Poll::Pending
+            }
+            State::Moving => {
+                let still_moving = self.driver.update()?;
+                if still_moving {
+                    Poll::Pending
+                } else {
+                    self.state = State::Finished;
+                    Poll::Ready(Ok(()))
+                }
+            }
+            State::Finished => Poll::Ready(Ok(())),
+        }
+    }
+
+    /// Wait until the operation completes
+    ///
+    /// This method will call [`Self::poll`] in a busy loop until the operation
+    /// has finished.
+    pub fn wait(&mut self) -> Result<(), Driver::Error> {
+        loop {
+            if let Poll::Ready(result) = self.poll() {
+                return result;
+            }
+        }
+    }
+
+    /// Drop the future and release the resources that were moved into it
+    pub fn release(self) -> Driver {
+        self.driver
+    }
+}
+
+enum State<Velocity> {
+    Initial {
+        max_velocity: Velocity,
+        target_step: u32,
+    },
+    Moving,
+    Finished,
+}

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -139,6 +139,11 @@ pub trait EnableMotionControl<Resources> {
 }
 
 /// Implemented by drivers that have motion control capabilities
+///
+/// A software-based fallback implementation exists in the [`motion_control`]
+/// module, for drivers that implement [SetDirection] and [Step].
+///
+/// [`motion_control`]: crate::motion_control
 pub trait MotionControl {
     /// The type used by the driver to represent velocity
     type Velocity: Copy;

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -125,3 +125,45 @@ pub trait Step {
     /// Provides access to the STEP pin
     fn step(&mut self) -> &mut Self::Step;
 }
+
+/// Enable motion control for a driver
+///
+/// The `Resources` type parameter defines the hardware resources required for
+/// motion control.
+pub trait EnableMotionControl<Resources> {
+    /// The type of the driver after motion control has been enabled
+    type WithMotionControl: MotionControl;
+
+    /// Enable step control
+    fn enable_motion_control(self, res: Resources) -> Self::WithMotionControl;
+}
+
+/// Implemented by drivers that have motion control capabilities
+pub trait MotionControl {
+    /// The type used by the driver to represent velocity
+    type Velocity: Copy;
+
+    /// The type error that can happen when using this trait
+    type Error;
+
+    /// Move to the given position
+    ///
+    /// This method must arrange for the motion to start, but must not block
+    /// until it is completed. If more attention is required during the motion,
+    /// this should be handled in [`MotionControl::update`].
+    fn move_to_position(
+        &mut self,
+        max_velocity: Self::Velocity,
+        target_step: u32,
+    ) -> Result<(), Self::Error>;
+
+    /// Update an ongoing motion
+    ///
+    /// This method may contain any code required to maintain an ongoing motion,
+    /// if required, or it might just check whether a motion is still ongoing.
+    ///
+    /// Return `true`, if motion is ongoing, `false` otherwise. If `false` is
+    /// returned, the caller may assume that this method doesn't need to be
+    /// called again, until starting another motion.
+    fn update(&mut self) -> Result<bool, Self::Error>;
+}

--- a/src/util/ref_mut.rs
+++ b/src/util/ref_mut.rs
@@ -5,7 +5,7 @@
 use embedded_hal::timer;
 use embedded_time::duration::Nanoseconds;
 
-use crate::traits::{SetDirection, SetStepMode, Step};
+use crate::traits::{MotionControl, SetDirection, SetStepMode, Step};
 
 /// Generic wrapper around a mutable reference
 ///
@@ -34,6 +34,26 @@ where
 
     fn try_wait(&mut self) -> nb::Result<(), Self::Error> {
         self.0.try_wait()
+    }
+}
+
+impl<'r, T> MotionControl for RefMut<'r, T>
+where
+    T: MotionControl,
+{
+    type Velocity = T::Velocity;
+    type Error = T::Error;
+
+    fn move_to_position(
+        &mut self,
+        max_velocity: Self::Velocity,
+        target_step: u32,
+    ) -> Result<(), Self::Error> {
+        self.0.move_to_position(max_velocity, target_step)
+    }
+
+    fn update(&mut self) -> Result<bool, Self::Error> {
+        self.0.update()
     }
 }
 


### PR DESCRIPTION
Defines motion control traits that drivers can implement, a high-level interface for `Stepper` that uses those traits, as well as a fallback implementation for drivers that don't support this in software (i.e. all of the currently supported ones) based on [RampMaker](https://github.com/flott-motion/ramp-maker).

As of now, there are some problems that I'd like to address in follow-up PRs:

- The target step is unsigned and direction is defined by the sign of the velocity. I think this is weird, and I don't remember why I did it that way (I've started working on this a while ago, before I implemented the required changes in RampMaker).
- The motion control API does not track the position internally, meaning the target step is always relative to the current position. This is not in line with what actual hardware is like, as far as I've seen.