### PR TITLE
Re-export `ramp_maker`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -131,6 +131,7 @@
 
 pub extern crate embedded_hal;
 pub extern crate embedded_time;
+pub extern crate ramp_maker;
 
 pub mod drivers;
 pub mod motion_control;


### PR DESCRIPTION
This provides convenience to users, who don't have to manage that
dependency themselves (and keep it in sync with the version used by
Step/Dir).