### PR TITLE
Change motion control API to accept absolute target position

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -158,21 +158,3 @@ pub enum Direction {
     /// driver's DIR signal set is LOW.
     Backward = -1,
 }
-
-impl Direction {
-    /// Create a `Direction` from a velocity value
-    ///
-    /// Expects the velocity value to be signed. Zero or a positive value will
-    /// result in forward direction, a negative value will result in backward
-    /// direction.
-    pub fn from_velocity<Velocity>(velocity: Velocity) -> Self
-    where
-        Velocity: num_traits::Signed,
-    {
-        if velocity.is_negative() {
-            Self::Backward
-        } else {
-            Self::Forward
-        }
-    }
-}

--- a/src/motion_control.rs
+++ b/src/motion_control.rs
@@ -116,6 +116,16 @@ where
     pub fn profile_mut(&mut self) -> &mut Profile {
         &mut self.profile
     }
+
+    /// Access the current step
+    pub fn current_step(&self) -> i32 {
+        self.current_step
+    }
+
+    /// Access the current direction
+    pub fn current_direction(&self) -> Direction {
+        self.current_direction
+    }
 }
 
 impl<Driver, Timer, Profile> MotionControl

--- a/src/motion_control.rs
+++ b/src/motion_control.rs
@@ -10,7 +10,6 @@ use core::{
 
 use embedded_hal::timer;
 use embedded_time::duration::Nanoseconds;
-use num_traits::Signed as _;
 use ramp_maker::MotionProfile;
 use replace_with::replace_with_and_return;
 
@@ -127,7 +126,7 @@ where
     Timer: timer::CountDown,
     Timer::Time: TryFrom<Nanoseconds>,
     Profile::Delay: TryInto<Nanoseconds>,
-    Profile::Velocity: Copy + num_traits::Signed,
+    Profile::Velocity: Copy,
 {
     type Velocity = Profile::Velocity;
     type Error = Error<Driver, Timer, Profile>;
@@ -139,10 +138,8 @@ where
     ) -> Result<(), Self::Error> {
         let steps_from_here = target_step - self.current_step;
 
-        self.profile.enter_position_mode(
-            max_velocity.abs(),
-            steps_from_here.abs() as u32,
-        );
+        self.profile
+            .enter_position_mode(max_velocity, steps_from_here.abs() as u32);
 
         let direction = if steps_from_here > 0 {
             Direction::Forward
@@ -472,7 +469,7 @@ where
     Timer: timer::CountDown,
     Timer::Time: TryFrom<Nanoseconds>,
     Profile::Delay: TryInto<Nanoseconds>,
-    Profile::Velocity: Copy + num_traits::Signed,
+    Profile::Velocity: Copy,
 {
     type WithMotionControl = SoftwareMotionControl<Driver, Timer, Profile>;
 

--- a/src/stepper/mod.rs
+++ b/src/stepper/mod.rs
@@ -377,7 +377,7 @@ impl<Driver> Stepper<Driver> {
     pub fn move_to_position<'r>(
         &'r mut self,
         max_velocity: Driver::Velocity,
-        target_step: u32,
+        target_step: i32,
     ) -> MoveToFuture<RefMut<'r, Driver>>
     where
         Driver: MotionControl,

--- a/src/stepper/move_to.rs
+++ b/src/stepper/move_to.rs
@@ -29,7 +29,7 @@ where
     pub fn new(
         driver: Driver,
         max_velocity: Driver::Velocity,
-        target_step: u32,
+        target_step: i32,
     ) -> Self {
         Self {
             driver,
@@ -95,7 +95,7 @@ where
 enum State<Velocity> {
     Initial {
         max_velocity: Velocity,
-        target_step: u32,
+        target_step: i32,
     },
     Moving,
     Finished,

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -159,7 +159,7 @@ pub trait MotionControl {
     fn move_to_position(
         &mut self,
         max_velocity: Self::Velocity,
-        target_step: u32,
+        target_step: i32,
     ) -> Result<(), Self::Error>;
 
     /// Update an ongoing motion

--- a/src/util/ref_mut.rs
+++ b/src/util/ref_mut.rs
@@ -47,7 +47,7 @@ where
     fn move_to_position(
         &mut self,
         max_velocity: Self::Velocity,
-        target_step: u32,
+        target_step: i32,
     ) -> Result<(), Self::Error> {
         self.0.move_to_position(max_velocity, target_step)
     }


### PR DESCRIPTION
Updates the software motion control to track the current step, which allows the motion control API to accept an absolute target position instead of a relative one. From what I've seen, this is more in line with what motion control hardware provides.