### PR TITLE
Support setting step more for software-motion-controlled driver

### DIFF
--- a/src/motion_control/error.rs
+++ b/src/motion_control/error.rs
@@ -101,3 +101,16 @@ pub enum TimeConversionError<
     /// Error converting from timer ticks to nanoseconds
     FromDelay(Delay::Error),
 }
+
+/// The software motion control was busy, or another generic error occurred
+#[derive(Debug)]
+pub enum BusyError<T> {
+    /// The software motion control was busy
+    ///
+    /// This happens while a movement is going on, and the driver is not
+    /// available.
+    Busy,
+
+    /// Another error has occurred
+    Other(T),
+}

--- a/src/motion_control/error.rs
+++ b/src/motion_control/error.rs
@@ -89,8 +89,8 @@ where
     }
 }
 
-#[derive(Debug)]
 /// An error occurred while converting between time formats
+#[derive(Debug)]
 pub enum TimeConversionError<
     Time: TryFrom<Nanoseconds>,
     Delay: TryInto<Nanoseconds>,

--- a/src/motion_control/mod.rs
+++ b/src/motion_control/mod.rs
@@ -7,7 +7,7 @@ mod state;
 
 pub use self::error::{BusyError, Error, TimeConversionError};
 
-use core::convert::{TryFrom, TryInto};
+use core::convert::{Infallible, TryFrom, TryInto};
 
 use embedded_hal::timer;
 use embedded_time::duration::Nanoseconds;
@@ -15,8 +15,11 @@ use ramp_maker::MotionProfile;
 use replace_with::replace_with_and_return;
 
 use crate::{
-    traits::{EnableMotionControl, MotionControl, SetDirection, Step},
-    Direction,
+    traits::{
+        EnableMotionControl, MotionControl, SetDirection, SetStepMode, Step,
+    },
+    util::ref_mut::RefMut,
+    Direction, SetStepModeFuture,
 };
 
 use self::state::State;
@@ -128,6 +131,43 @@ where
     /// Access the current direction
     pub fn current_direction(&self) -> Direction {
         self.current_direction
+    }
+
+    /// Set step mode of the wrapped driver
+    ///
+    /// This method is a more convenient alternative to
+    /// [`Stepper::set_step_mode], which requires a timer, while this methods
+    /// reuses the timer that `SoftwareMotionControl` already owns.
+    ///
+    /// However, while [`Stepper::set_step_mode`] is part of the generic API,
+    /// this method is only available, if you statically know that you're
+    /// working with a driver wrapped by `SoftwareMotionControl`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`BusyError::Busy`], if a motion is ongoing.
+    ///
+    /// [`Stepper::set_step_mode`]: crate::Stepper::set_step_mode
+    pub fn set_step_mode(
+        &mut self,
+        step_mode: Driver::StepMode,
+    ) -> Result<
+        SetStepModeFuture<RefMut<Driver>, RefMut<Timer>>,
+        BusyError<Infallible>,
+    >
+    where
+        Driver: SetStepMode,
+        Timer: timer::CountDown,
+        Timer::Time: TryFrom<Nanoseconds>,
+    {
+        let future = match &mut self.state {
+            State::Idle { driver, timer } => {
+                SetStepModeFuture::new(step_mode, RefMut(driver), RefMut(timer))
+            }
+            _ => return Err(BusyError::Busy),
+        };
+
+        Ok(future)
     }
 }
 


### PR DESCRIPTION
Makes `SetStepMode` functionality available through `SoftwareMotionControl`, both as a direct trait implementation and a convenience method.