### PR TITLE
Remove the need for a custom numeric type

### DIFF
--- a/src/motion_control/conversion.rs
+++ b/src/motion_control/conversion.rs
@@ -1,0 +1,18 @@
+/// Converts delay values from RampMaker into timer ticks
+///
+/// RampMaker is agnostic over the units used, and the unit of the timer ticks
+/// depend on the target platform. This trait allows Step/Dir to convert between
+/// both types. The user must supply an implementation that matches their
+/// environment.
+///
+/// The `Delay` parameter specifies the type of delay value used by RampMaker.
+pub trait DelayToTicks<Delay> {
+    /// The timer ticks the delay is being converted into
+    type Ticks;
+
+    /// The error that can happen during conversion
+    type Error;
+
+    /// Convert delay value into timer ticks
+    fn delay_to_ticks(&self, delay: Delay) -> Result<Self::Ticks, Self::Error>;
+}

--- a/src/motion_control/error.rs
+++ b/src/motion_control/error.rs
@@ -95,7 +95,7 @@ pub enum TimeConversionError<Time: TryFrom<Nanoseconds>, Delay: TryInto<Time>> {
     /// Error converting from nanoseconds to timer ticks
     ToTimerTime(Time::Error),
 
-    /// Error converting from timer ticks to nanoseconds
+    /// Error converting from RampMaker delay value to timer ticks
     FromDelay(Delay::Error),
 }
 

--- a/src/motion_control/error.rs
+++ b/src/motion_control/error.rs
@@ -96,7 +96,7 @@ pub enum TimeConversionError<Time: TryFrom<Nanoseconds>, Delay: TryInto<Time>> {
     NanosecondsToTicks(Time::Error),
 
     /// Error converting from RampMaker delay value to timer ticks
-    FromDelay(Delay::Error),
+    DelayToTicks(Delay::Error),
 }
 
 /// The software motion control was busy, or another generic error occurred

--- a/src/motion_control/error.rs
+++ b/src/motion_control/error.rs
@@ -39,7 +39,12 @@ where
     ),
 
     /// Error while converting between time formats
-    TimeConversion(TimeConversionError<Timer::Time, Profile::Delay>),
+    TimeConversion(
+        TimeConversionError<
+            <Timer::Time as TryFrom<Nanoseconds>>::Error,
+            <Profile::Delay as TryInto<Timer::Time>>::Error,
+        >,
+    ),
 
     /// Error while waiting for a step to finish
     StepDelay(Timer::Error),
@@ -91,12 +96,12 @@ where
 
 /// An error occurred while converting between time formats
 #[derive(Debug)]
-pub enum TimeConversionError<Time: TryFrom<Nanoseconds>, Delay: TryInto<Time>> {
+pub enum TimeConversionError<TimeError, DelayError> {
     /// Error converting from nanoseconds to timer ticks
-    NanosecondsToTicks(Time::Error),
+    NanosecondsToTicks(TimeError),
 
     /// Error converting from RampMaker delay value to timer ticks
-    DelayToTicks(Delay::Error),
+    DelayToTicks(DelayError),
 }
 
 /// The software motion control was busy, or another generic error occurred

--- a/src/motion_control/error.rs
+++ b/src/motion_control/error.rs
@@ -93,7 +93,7 @@ where
 #[derive(Debug)]
 pub enum TimeConversionError<Time: TryFrom<Nanoseconds>, Delay: TryInto<Time>> {
     /// Error converting from nanoseconds to timer ticks
-    ToTimerTime(Time::Error),
+    NanosecondsToTicks(Time::Error),
 
     /// Error converting from RampMaker delay value to timer ticks
     FromDelay(Delay::Error),

--- a/src/motion_control/error.rs
+++ b/src/motion_control/error.rs
@@ -18,7 +18,7 @@ where
     Timer: timer::CountDown,
     Profile: MotionProfile,
     Timer::Time: TryFrom<Nanoseconds>,
-    Profile::Delay: TryInto<Nanoseconds>,
+    Profile::Delay: TryInto<Timer::Time>,
 {
     /// Error while setting direction
     SetDirection(
@@ -52,14 +52,14 @@ where
     Timer: timer::CountDown,
     Profile: MotionProfile,
     Timer::Time: TryFrom<Nanoseconds>,
-    Profile::Delay: TryInto<Nanoseconds>,
+    Profile::Delay: TryInto<Timer::Time>,
     <Driver as SetDirection>::Error: fmt::Debug,
     <Driver as Step>::Error: fmt::Debug,
     Timer::Error: fmt::Debug,
     Timer::Time: fmt::Debug,
     <Timer::Time as TryFrom<Nanoseconds>>::Error: fmt::Debug,
     Profile::Delay: fmt::Debug,
-    <Profile::Delay as TryInto<Nanoseconds>>::Error: fmt::Debug,
+    <Profile::Delay as TryInto<Timer::Time>>::Error: fmt::Debug,
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
@@ -91,10 +91,7 @@ where
 
 /// An error occurred while converting between time formats
 #[derive(Debug)]
-pub enum TimeConversionError<
-    Time: TryFrom<Nanoseconds>,
-    Delay: TryInto<Nanoseconds>,
-> {
+pub enum TimeConversionError<Time: TryFrom<Nanoseconds>, Delay: TryInto<Time>> {
     /// Error converting from nanoseconds to timer ticks
     ToTimerTime(Time::Error),
 

--- a/src/motion_control/mod.rs
+++ b/src/motion_control/mod.rs
@@ -7,7 +7,10 @@ mod state;
 
 pub use self::error::{BusyError, Error, TimeConversionError};
 
-use core::convert::{Infallible, TryFrom, TryInto};
+use core::{
+    convert::{Infallible, TryFrom, TryInto},
+    ops,
+};
 
 use embedded_hal::timer;
 use embedded_time::duration::Nanoseconds;
@@ -177,8 +180,8 @@ where
     Driver: SetDirection + Step,
     Profile: MotionProfile,
     Timer: timer::CountDown,
-    Timer::Time: TryFrom<Nanoseconds>,
-    Profile::Delay: TryInto<Nanoseconds>,
+    Timer::Time: TryFrom<Nanoseconds> + ops::Sub<Output = Timer::Time>,
+    Profile::Delay: TryInto<Timer::Time>,
     Profile::Velocity: Copy,
 {
     type Velocity = Profile::Velocity;
@@ -278,8 +281,8 @@ where
     Driver: SetDirection + Step,
     Profile: MotionProfile,
     Timer: timer::CountDown,
-    Timer::Time: TryFrom<Nanoseconds>,
-    Profile::Delay: TryInto<Nanoseconds>,
+    Timer::Time: TryFrom<Nanoseconds> + ops::Sub<Output = Timer::Time>,
+    Profile::Delay: TryInto<Timer::Time>,
     Profile::Velocity: Copy,
 {
     type WithMotionControl = SoftwareMotionControl<Driver, Timer, Profile>;

--- a/src/motion_control/mod.rs
+++ b/src/motion_control/mod.rs
@@ -185,7 +185,8 @@ where
     Profile::Velocity: Copy,
 {
     type Velocity = Profile::Velocity;
-    type Error = Error<Driver, Timer, Profile>;
+    type Error =
+        Error<Driver, Timer, <Profile::Delay as TryInto<Timer::Time>>::Error>;
 
     fn move_to_position(
         &mut self,

--- a/src/motion_control/mod.rs
+++ b/src/motion_control/mod.rs
@@ -12,7 +12,7 @@ pub use self::{
 };
 
 use core::{
-    convert::{Infallible, TryFrom, TryInto},
+    convert::{Infallible, TryFrom},
     ops,
 };
 
@@ -193,8 +193,6 @@ where
     Driver: SetDirection + Step,
     Profile: MotionProfile,
     Timer: timer::CountDown,
-    Timer::Time: TryFrom<Nanoseconds> + ops::Sub<Output = Timer::Time>,
-    Profile::Delay: TryInto<Timer::Time>,
     Profile::Velocity: Copy,
     Convert: DelayToTicks<Profile::Delay, Ticks = Timer::Time>,
     Convert::Ticks: TryFrom<Nanoseconds> + ops::Sub<Output = Convert::Ticks>,
@@ -299,8 +297,6 @@ where
     Driver: SetDirection + Step,
     Profile: MotionProfile,
     Timer: timer::CountDown,
-    Timer::Time: TryFrom<Nanoseconds> + ops::Sub<Output = Timer::Time>,
-    Profile::Delay: TryInto<Timer::Time>,
     Profile::Velocity: Copy,
     Convert: DelayToTicks<Profile::Delay, Ticks = Timer::Time>,
     Convert::Ticks: TryFrom<Nanoseconds> + ops::Sub<Output = Convert::Ticks>,

--- a/src/motion_control/state.rs
+++ b/src/motion_control/state.rs
@@ -206,7 +206,7 @@ where
         .map_err(|err| TimeConversionError::FromDelay(err))?;
     let pulse_length: Time = pulse_length
         .try_into()
-        .map_err(|err| TimeConversionError::ToTimerTime(err))?;
+        .map_err(|err| TimeConversionError::NanosecondsToTicks(err))?;
 
     let delay_left: Time = delay - pulse_length;
     Ok(delay_left)

--- a/src/motion_control/state.rs
+++ b/src/motion_control/state.rs
@@ -196,7 +196,7 @@ where
 fn delay_left<Delay, Time>(
     delay: Delay,
     pulse_length: Nanoseconds,
-) -> Result<Time, TimeConversionError<Time, Delay>>
+) -> Result<Time, TimeConversionError<Time::Error, Delay::Error>>
 where
     Time: TryFrom<Nanoseconds> + ops::Sub<Output = Time>,
     Delay: TryInto<Time>,

--- a/src/motion_control/state.rs
+++ b/src/motion_control/state.rs
@@ -208,6 +208,6 @@ where
         .try_into()
         .map_err(|err| TimeConversionError::NanosecondsToTicks(err))?;
 
-    let delay_left: Time = delay - pulse_length;
+    let delay_left = delay - pulse_length;
     Ok(delay_left)
 }

--- a/src/motion_control/state.rs
+++ b/src/motion_control/state.rs
@@ -203,7 +203,7 @@ where
 {
     let delay: Time = delay
         .try_into()
-        .map_err(|err| TimeConversionError::FromDelay(err))?;
+        .map_err(|err| TimeConversionError::DelayToTicks(err))?;
     let pulse_length: Time = pulse_length
         .try_into()
         .map_err(|err| TimeConversionError::NanosecondsToTicks(err))?;

--- a/src/motion_control/state.rs
+++ b/src/motion_control/state.rs
@@ -39,7 +39,10 @@ pub fn update<Driver, Timer, Profile>(
     current_step: &mut i32,
     current_direction: &mut Direction,
 ) -> (
-    Result<bool, Error<Driver, Timer, Profile>>,
+    Result<
+        bool,
+        Error<Driver, Timer, <Profile::Delay as TryInto<Timer::Time>>::Error>,
+    >,
     State<Driver, Timer, Profile>,
 )
 where

--- a/src/motion_control/state.rs
+++ b/src/motion_control/state.rs
@@ -1,5 +1,5 @@
 use core::{
-    convert::{TryFrom, TryInto},
+    convert::{TryFrom, TryInto as _},
     ops,
     task::Poll,
 };
@@ -49,9 +49,7 @@ pub fn update<Driver, Timer, Profile, Convert>(
 where
     Driver: SetDirection + Step,
     Timer: timer::CountDown,
-    Timer::Time: TryFrom<Nanoseconds> + ops::Sub<Output = Timer::Time>,
     Profile: MotionProfile,
-    Profile::Delay: TryInto<Timer::Time>,
     Convert: DelayToTicks<Profile::Delay, Ticks = Timer::Time>,
     Convert::Ticks: TryFrom<Nanoseconds> + ops::Sub<Output = Convert::Ticks>,
 {
@@ -214,7 +212,6 @@ fn delay_left<Delay, Convert>(
     >,
 >
 where
-    Delay: TryInto<Convert::Ticks>,
     Convert: DelayToTicks<Delay>,
     Convert::Ticks: TryFrom<Nanoseconds> + ops::Sub<Output = Convert::Ticks>,
 {


### PR DESCRIPTION
Replaces the `TryInto` trait bound that required a custom numeric type with an explicit converter that must implement the new `DelayToTicks` trait.