### PR TITLE
Simplify `motion_control::Error`

### DIFF
--- a/src/motion_control/error.rs
+++ b/src/motion_control/error.rs
@@ -8,7 +8,7 @@ use crate::traits::{SetDirection, Step};
 /// An error that can occur while using [`SoftwareMotionControl`]
 ///
 /// [`SoftwareMotionControl`]: super::SoftwareMotionControl
-pub enum Error<Driver, Timer, ConvertError>
+pub enum Error<Driver, Timer, DelayToTicksError>
 where
     Driver: SetDirection + Step,
     Timer: timer::CountDown,
@@ -36,7 +36,7 @@ where
     TimeConversion(
         TimeConversionError<
             <Timer::Time as TryFrom<Nanoseconds>>::Error,
-            ConvertError,
+            DelayToTicksError,
         >,
     ),
 
@@ -45,8 +45,8 @@ where
 }
 
 // Can't `#[derive(Debug)]`, as that can't generate the required trait bounds.
-impl<Driver, Timer, ConvertError> fmt::Debug
-    for Error<Driver, Timer, ConvertError>
+impl<Driver, Timer, DelayToTicksError> fmt::Debug
+    for Error<Driver, Timer, DelayToTicksError>
 where
     Driver: SetDirection + Step,
     Timer: timer::CountDown,
@@ -56,7 +56,7 @@ where
     Timer::Error: fmt::Debug,
     Timer::Time: fmt::Debug,
     <Timer::Time as TryFrom<Nanoseconds>>::Error: fmt::Debug,
-    ConvertError: fmt::Debug,
+    DelayToTicksError: fmt::Debug,
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {

--- a/src/motion_control/error.rs
+++ b/src/motion_control/error.rs
@@ -88,12 +88,12 @@ where
 
 /// An error occurred while converting between time formats
 #[derive(Debug)]
-pub enum TimeConversionError<TimeError, DelayError> {
+pub enum TimeConversionError<NanosecondsToTicksError, DelayToTicksError> {
     /// Error converting from nanoseconds to timer ticks
-    NanosecondsToTicks(TimeError),
+    NanosecondsToTicks(NanosecondsToTicksError),
 
     /// Error converting from RampMaker delay value to timer ticks
-    DelayToTicks(DelayError),
+    DelayToTicks(DelayToTicksError),
 }
 
 /// The software motion control was busy, or another generic error occurred

--- a/src/motion_control/error.rs
+++ b/src/motion_control/error.rs
@@ -1,7 +1,6 @@
-use core::{convert::TryFrom, fmt};
+use core::fmt;
 
 use embedded_hal::timer;
-use embedded_time::duration::Nanoseconds;
 
 use crate::traits::{SetDirection, Step};
 
@@ -46,11 +45,9 @@ impl<Driver, Timer, NanosecondsToTicksError, DelayToTicksError> fmt::Debug
 where
     Driver: SetDirection + Step,
     Timer: timer::CountDown,
-    Timer::Time: TryFrom<Nanoseconds>,
     <Driver as SetDirection>::Error: fmt::Debug,
     <Driver as Step>::Error: fmt::Debug,
     Timer::Error: fmt::Debug,
-    Timer::Time: fmt::Debug,
     NanosecondsToTicksError: fmt::Debug,
     DelayToTicksError: fmt::Debug,
 {

--- a/src/motion_control/error.rs
+++ b/src/motion_control/error.rs
@@ -1,8 +1,7 @@
-use core::fmt;
-
 /// An error that can occur while using [`SoftwareMotionControl`]
 ///
 /// [`SoftwareMotionControl`]: super::SoftwareMotionControl
+#[derive(Debug)]
 pub enum Error<
     SetDirectionError,
     StepError,
@@ -25,56 +24,6 @@ pub enum Error<
 
     /// Error while waiting for a step to finish
     StepDelay(TimerError),
-}
-
-// Can't `#[derive(Debug)]`, as that can't generate the required trait bounds.
-impl<
-        SetDirectionError,
-        StepError,
-        TimerError,
-        NanosecondsToTicksError,
-        DelayToTicksError,
-    > fmt::Debug
-    for Error<
-        SetDirectionError,
-        StepError,
-        TimerError,
-        NanosecondsToTicksError,
-        DelayToTicksError,
-    >
-where
-    SetDirectionError: fmt::Debug,
-    StepError: fmt::Debug,
-    TimerError: fmt::Debug,
-    NanosecondsToTicksError: fmt::Debug,
-    DelayToTicksError: fmt::Debug,
-{
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match self {
-            Self::SetDirection(err) => {
-                write!(f, "SetDirection(")?;
-                err.fmt(f)?;
-                write!(f, ")")?;
-            }
-            Self::Step(err) => {
-                write!(f, "Step(")?;
-                err.fmt(f)?;
-                write!(f, ")")?;
-            }
-            Self::TimeConversion(err) => {
-                write!(f, "TimeConversion(")?;
-                err.fmt(f)?;
-                write!(f, ")")?;
-            }
-            Self::StepDelay(err) => {
-                write!(f, "StepDelay(")?;
-                err.fmt(f)?;
-                write!(f, ")")?;
-            }
-        }
-
-        Ok(())
-    }
 }
 
 /// An error occurred while converting between time formats

--- a/src/motion_control/error.rs
+++ b/src/motion_control/error.rs
@@ -1,13 +1,18 @@
 use core::fmt;
 
-use crate::traits::{SetDirection, Step};
+use crate::traits::SetDirection;
 
 /// An error that can occur while using [`SoftwareMotionControl`]
 ///
 /// [`SoftwareMotionControl`]: super::SoftwareMotionControl
-pub enum Error<Driver, TimerError, NanosecondsToTicksError, DelayToTicksError>
-where
-    Driver: SetDirection + Step,
+pub enum Error<
+    Driver,
+    StepError,
+    TimerError,
+    NanosecondsToTicksError,
+    DelayToTicksError,
+> where
+    Driver: SetDirection,
 {
     /// Error while setting direction
     SetDirection(
@@ -19,13 +24,7 @@ where
     ),
 
     /// Error while stepping the motor
-    Step(
-        crate::Error<
-            <Driver as Step>::Error,
-            NanosecondsToTicksError,
-            TimerError,
-        >,
-    ),
+    Step(crate::Error<StepError, NanosecondsToTicksError, TimerError>),
 
     /// Error while converting between time formats
     TimeConversion(
@@ -37,12 +36,24 @@ where
 }
 
 // Can't `#[derive(Debug)]`, as that can't generate the required trait bounds.
-impl<Driver, TimerError, NanosecondsToTicksError, DelayToTicksError> fmt::Debug
-    for Error<Driver, TimerError, NanosecondsToTicksError, DelayToTicksError>
+impl<
+        Driver,
+        StepError,
+        TimerError,
+        NanosecondsToTicksError,
+        DelayToTicksError,
+    > fmt::Debug
+    for Error<
+        Driver,
+        StepError,
+        TimerError,
+        NanosecondsToTicksError,
+        DelayToTicksError,
+    >
 where
-    Driver: SetDirection + Step,
+    Driver: SetDirection,
     <Driver as SetDirection>::Error: fmt::Debug,
-    <Driver as Step>::Error: fmt::Debug,
+    StepError: fmt::Debug,
     TimerError: fmt::Debug,
     NanosecondsToTicksError: fmt::Debug,
     DelayToTicksError: fmt::Debug,

--- a/src/motion_control/error.rs
+++ b/src/motion_control/error.rs
@@ -8,17 +8,16 @@ use crate::traits::{SetDirection, Step};
 /// An error that can occur while using [`SoftwareMotionControl`]
 ///
 /// [`SoftwareMotionControl`]: super::SoftwareMotionControl
-pub enum Error<Driver, Timer, DelayToTicksError>
+pub enum Error<Driver, Timer, NanosecondsToTicksError, DelayToTicksError>
 where
     Driver: SetDirection + Step,
     Timer: timer::CountDown,
-    Timer::Time: TryFrom<Nanoseconds>,
 {
     /// Error while setting direction
     SetDirection(
         crate::Error<
             <Driver as SetDirection>::Error,
-            <Timer::Time as TryFrom<Nanoseconds>>::Error,
+            NanosecondsToTicksError,
             Timer::Error,
         >,
     ),
@@ -27,17 +26,14 @@ where
     Step(
         crate::Error<
             <Driver as Step>::Error,
-            <Timer::Time as TryFrom<Nanoseconds>>::Error,
+            NanosecondsToTicksError,
             Timer::Error,
         >,
     ),
 
     /// Error while converting between time formats
     TimeConversion(
-        TimeConversionError<
-            <Timer::Time as TryFrom<Nanoseconds>>::Error,
-            DelayToTicksError,
-        >,
+        TimeConversionError<NanosecondsToTicksError, DelayToTicksError>,
     ),
 
     /// Error while waiting for a step to finish
@@ -45,8 +41,8 @@ where
 }
 
 // Can't `#[derive(Debug)]`, as that can't generate the required trait bounds.
-impl<Driver, Timer, DelayToTicksError> fmt::Debug
-    for Error<Driver, Timer, DelayToTicksError>
+impl<Driver, Timer, NanosecondsToTicksError, DelayToTicksError> fmt::Debug
+    for Error<Driver, Timer, NanosecondsToTicksError, DelayToTicksError>
 where
     Driver: SetDirection + Step,
     Timer: timer::CountDown,
@@ -55,7 +51,7 @@ where
     <Driver as Step>::Error: fmt::Debug,
     Timer::Error: fmt::Debug,
     Timer::Time: fmt::Debug,
-    <Timer::Time as TryFrom<Nanoseconds>>::Error: fmt::Debug,
+    NanosecondsToTicksError: fmt::Debug,
     DelayToTicksError: fmt::Debug,
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {

--- a/src/motion_control/error.rs
+++ b/src/motion_control/error.rs
@@ -1,23 +1,20 @@
 use core::fmt;
 
-use embedded_hal::timer;
-
 use crate::traits::{SetDirection, Step};
 
 /// An error that can occur while using [`SoftwareMotionControl`]
 ///
 /// [`SoftwareMotionControl`]: super::SoftwareMotionControl
-pub enum Error<Driver, Timer, NanosecondsToTicksError, DelayToTicksError>
+pub enum Error<Driver, TimerError, NanosecondsToTicksError, DelayToTicksError>
 where
     Driver: SetDirection + Step,
-    Timer: timer::CountDown,
 {
     /// Error while setting direction
     SetDirection(
         crate::Error<
             <Driver as SetDirection>::Error,
             NanosecondsToTicksError,
-            Timer::Error,
+            TimerError,
         >,
     ),
 
@@ -26,7 +23,7 @@ where
         crate::Error<
             <Driver as Step>::Error,
             NanosecondsToTicksError,
-            Timer::Error,
+            TimerError,
         >,
     ),
 
@@ -36,18 +33,17 @@ where
     ),
 
     /// Error while waiting for a step to finish
-    StepDelay(Timer::Error),
+    StepDelay(TimerError),
 }
 
 // Can't `#[derive(Debug)]`, as that can't generate the required trait bounds.
-impl<Driver, Timer, NanosecondsToTicksError, DelayToTicksError> fmt::Debug
-    for Error<Driver, Timer, NanosecondsToTicksError, DelayToTicksError>
+impl<Driver, TimerError, NanosecondsToTicksError, DelayToTicksError> fmt::Debug
+    for Error<Driver, TimerError, NanosecondsToTicksError, DelayToTicksError>
 where
     Driver: SetDirection + Step,
-    Timer: timer::CountDown,
     <Driver as SetDirection>::Error: fmt::Debug,
     <Driver as Step>::Error: fmt::Debug,
-    Timer::Error: fmt::Debug,
+    TimerError: fmt::Debug,
     NanosecondsToTicksError: fmt::Debug,
     DelayToTicksError: fmt::Debug,
 {

--- a/src/motion_control/error.rs
+++ b/src/motion_control/error.rs
@@ -1,26 +1,18 @@
 use core::fmt;
 
-use crate::traits::SetDirection;
-
 /// An error that can occur while using [`SoftwareMotionControl`]
 ///
 /// [`SoftwareMotionControl`]: super::SoftwareMotionControl
 pub enum Error<
-    Driver,
+    SetDirectionError,
     StepError,
     TimerError,
     NanosecondsToTicksError,
     DelayToTicksError,
-> where
-    Driver: SetDirection,
-{
+> {
     /// Error while setting direction
     SetDirection(
-        crate::Error<
-            <Driver as SetDirection>::Error,
-            NanosecondsToTicksError,
-            TimerError,
-        >,
+        crate::Error<SetDirectionError, NanosecondsToTicksError, TimerError>,
     ),
 
     /// Error while stepping the motor
@@ -37,22 +29,21 @@ pub enum Error<
 
 // Can't `#[derive(Debug)]`, as that can't generate the required trait bounds.
 impl<
-        Driver,
+        SetDirectionError,
         StepError,
         TimerError,
         NanosecondsToTicksError,
         DelayToTicksError,
     > fmt::Debug
     for Error<
-        Driver,
+        SetDirectionError,
         StepError,
         TimerError,
         NanosecondsToTicksError,
         DelayToTicksError,
     >
 where
-    Driver: SetDirection,
-    <Driver as SetDirection>::Error: fmt::Debug,
+    SetDirectionError: fmt::Debug,
     StepError: fmt::Debug,
     TimerError: fmt::Debug,
     NanosecondsToTicksError: fmt::Debug,

--- a/src/motion_control/mod.rs
+++ b/src/motion_control/mod.rs
@@ -200,6 +200,7 @@ where
     type Velocity = Profile::Velocity;
     type Error = Error<
         Driver,
+        <Driver as Step>::Error,
         Timer::Error,
         <Timer::Time as TryFrom<Nanoseconds>>::Error,
         Convert::Error,

--- a/src/motion_control/mod.rs
+++ b/src/motion_control/mod.rs
@@ -199,7 +199,7 @@ where
 {
     type Velocity = Profile::Velocity;
     type Error = Error<
-        Driver,
+        <Driver as SetDirection>::Error,
         <Driver as Step>::Error,
         Timer::Error,
         <Timer::Time as TryFrom<Nanoseconds>>::Error,

--- a/src/motion_control/mod.rs
+++ b/src/motion_control/mod.rs
@@ -198,7 +198,12 @@ where
     Convert::Ticks: TryFrom<Nanoseconds> + ops::Sub<Output = Convert::Ticks>,
 {
     type Velocity = Profile::Velocity;
-    type Error = Error<Driver, Timer, Convert::Error>;
+    type Error = Error<
+        Driver,
+        Timer,
+        <Timer::Time as TryFrom<Nanoseconds>>::Error,
+        Convert::Error,
+    >;
 
     fn move_to_position(
         &mut self,

--- a/src/motion_control/mod.rs
+++ b/src/motion_control/mod.rs
@@ -200,7 +200,7 @@ where
     type Velocity = Profile::Velocity;
     type Error = Error<
         Driver,
-        Timer,
+        Timer::Error,
         <Timer::Time as TryFrom<Nanoseconds>>::Error,
         Convert::Error,
     >;

--- a/src/motion_control/state.rs
+++ b/src/motion_control/state.rs
@@ -43,7 +43,15 @@ pub fn update<Driver, Timer, Profile, Convert>(
     current_direction: &mut Direction,
     convert: &Convert,
 ) -> (
-    Result<bool, Error<Driver, Timer, Convert::Error>>,
+    Result<
+        bool,
+        Error<
+            Driver,
+            Timer,
+            <Timer::Time as TryFrom<Nanoseconds>>::Error,
+            Convert::Error,
+        >,
+    >,
     State<Driver, Timer, Profile>,
 )
 where

--- a/src/motion_control/state.rs
+++ b/src/motion_control/state.rs
@@ -47,6 +47,7 @@ pub fn update<Driver, Timer, Profile, Convert>(
         bool,
         Error<
             Driver,
+            <Driver as Step>::Error,
             Timer::Error,
             <Timer::Time as TryFrom<Nanoseconds>>::Error,
             Convert::Error,

--- a/src/motion_control/state.rs
+++ b/src/motion_control/state.rs
@@ -46,7 +46,7 @@ pub fn update<Driver, Timer, Profile, Convert>(
     Result<
         bool,
         Error<
-            Driver,
+            <Driver as SetDirection>::Error,
             <Driver as Step>::Error,
             Timer::Error,
             <Timer::Time as TryFrom<Nanoseconds>>::Error,

--- a/src/motion_control/state.rs
+++ b/src/motion_control/state.rs
@@ -47,7 +47,7 @@ pub fn update<Driver, Timer, Profile, Convert>(
         bool,
         Error<
             Driver,
-            Timer,
+            Timer::Error,
             <Timer::Time as TryFrom<Nanoseconds>>::Error,
             Convert::Error,
         >,


### PR DESCRIPTION
Remove all trait bounds from `motion_control::Error`, simplifying the enum significantly. This comes at the cost of more type parameters, but I believe the reduced complexity is worth it. It is already bearing fruit in this pull request, allowing for the replacement of the custom `Debug` implementation with a much simpler (and less error-prone) `#[derive(Debug)]`. It's also going to make some conversions I'd like to implement between error types much more practical.