### PR TITLE
Use motion control interface in example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,11 @@ version          = "0.1.7"
 default-features = false
 
 
+[dev-dependencies]
+fixed   = "1.6.0"
+typenum = "1.12.0"
+
+
 [features]
 default = ["drv8825", "stspin220"]
 drv8825 = []


### PR DESCRIPTION
The high-level motion control interface is more powerful, more
convenient, and more universal (supported for all STEP/DIR drivers via
software fallback, as well as any motion control chips that will be
supported in the future). It makes sense to prefer it over the
lower-level interface in the documentation.